### PR TITLE
Enable custom __GIT_PROMPT_DIR as an env var

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,4 +1,7 @@
-__GIT_PROMPT_DIR=~/.bash
+if [ "x$__GIT_PROMPT_DIR" == "x" ]
+then
+  __GIT_PROMPT_DIR=~/.bash
+fi
 
 # Colors
 # Reset


### PR DESCRIPTION
I'd like to directly point bash to where I checked out the source code.
With this change I can customize at least the base directory with an environment variable while the default value is still there.
