### PR TITLE
Prevent pollution of the global namespace

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,107 +1,85 @@
-if [ "x$__GIT_PROMPT_DIR" == "x" ]
-then
-  __GIT_PROMPT_DIR=~/.bash
-fi
 
-# Colors
-# Reset
-ResetColor="\[\033[0m\]"       # Text Reset
+function git_prompt_config() {
+  # Colors
+  local ResetColor="\[\033[0m\]"
+  local BoldGreen="\[\033[1;32m\]"
+  local BoldBlue="\[\033[1;34m\]"
+  local Magenta="\[\033[1;95m\]"
+  local Yellow="\[\033[1;33m\]"
+  local White="\[\033[37m\]"
+  local Blue="\[\033[0;34m\]"
+  local Red="\[\033[0;31m\]"
 
-# Regular Colors
-Red="\[\033[0;31m\]"          # Red
-Yellow="\[\033[0;33m\]"       # Yellow
-Blue="\[\033[0;34m\]"         # Blue
-WHITE='\[\033[37m\]'
+  # Default values for the appearance of the prompt. Configure at will.
+  GIT_PROMPT_PREFIX="["
+  GIT_PROMPT_SUFFIX="]"
+  GIT_PROMPT_SEPARATOR="|"
+  GIT_PROMPT_BRANCH="${Magenta}"
+  GIT_PROMPT_STAGED="${Red}● "
+  GIT_PROMPT_CONFLICTS="${Red}✖ "
+  GIT_PROMPT_CHANGED="${Blue}✚ "
+  GIT_PROMPT_REMOTE=" "
+  GIT_PROMPT_UNTRACKED="…"
+  GIT_PROMPT_CLEAN="${BoldGreen}✔"
 
-# Bold
-BGreen="\[\033[1;32m\]"       # Green
-
-# High Intensty
-IBlack="\[\033[0;90m\]"       # Black
-
-# Bold High Intensty
-Magenta="\[\033[1;95m\]"     # Purple
-
-# Various variables you might want for your PS1 prompt instead
-Time12a="\@"
-PathShort="\w"
-
-# Default values for the appearance of the prompt. Configure at will.
-GIT_PROMPT_PREFIX="["
-GIT_PROMPT_SUFFIX="]"
-GIT_PROMPT_SEPARATOR="|"
-GIT_PROMPT_BRANCH="${Magenta}"
-GIT_PROMPT_STAGED="${Red}● "
-GIT_PROMPT_CONFLICTS="${Red}✖ "
-GIT_PROMPT_CHANGED="${Blue}✚ "
-GIT_PROMPT_REMOTE=" "
-GIT_PROMPT_UNTRACKED="…"
-GIT_PROMPT_CLEAN="${BGreen}✔"
-
-PROMPT_START="$Yellow$PathShort$ResetColor"
-PROMPT_END=" \n$WHITE$Time12a$ResetColor $ "
-
-
-function update_current_git_vars() {
-    unset __CURRENT_GIT_STATUS
-    local gitstatus="${__GIT_PROMPT_DIR}/gitstatus.py"
-    
-    _GIT_STATUS=$(python $gitstatus)
-    __CURRENT_GIT_STATUS=($_GIT_STATUS)
-	GIT_BRANCH=${__CURRENT_GIT_STATUS[0]}
-	GIT_REMOTE=${__CURRENT_GIT_STATUS[1]}
-    if [[ "." == "$GIT_REMOTE" ]]; then
-		unset GIT_REMOTE
-	fi
-	GIT_STAGED=${__CURRENT_GIT_STATUS[2]}
-	GIT_CONFLICTS=${__CURRENT_GIT_STATUS[3]}
-	GIT_CHANGED=${__CURRENT_GIT_STATUS[4]}
-	GIT_UNTRACKED=${__CURRENT_GIT_STATUS[5]}
-	GIT_CLEAN=${__CURRENT_GIT_STATUS[6]}
+  PROMPT_START="${Yellow}\w${ResetColor}"
+  PROMPT_END=" \n${White}\@${ResetColor} $ "
 }
 
 function setGitPrompt() {
-	update_current_git_vars
-	set_virtualenv
+  local ResetColor="\[\033[0m\]"
 
-	if [ -n "$__CURRENT_GIT_STATUS" ]; then
-	  STATUS=" $GIT_PROMPT_PREFIX$GIT_PROMPT_BRANCH$GIT_BRANCH$ResetColor"
+  local -a GitStatus
+  GitStatus=($("${__GIT_PROMPT_DIR:-${HOME}/.bash}/gitstatus.py" 2>/dev/null))
 
-	  if [ -n "$GIT_REMOTE" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_REMOTE$GIT_REMOTE$ResetColor"
-	  fi
+  local GIT_PROMPT_PREFIX
+  local GIT_PROMPT_SUFFIX
+  local GIT_PROMPT_SEPARATOR
+  local GIT_PROMPT_BRANCH
+  local GIT_PROMPT_STAGED
+  local GIT_PROMPT_CONFLICTS
+  local GIT_PROMPT_CHANGED
+  local GIT_PROMPT_REMOTE
+  local GIT_PROMPT_UNTRACKED
+  local GIT_PROMPT_CLEAN
+  local PROMPT_START
+  local PROMPT_END
+  git_prompt_config
 
-	  STATUS="$STATUS$GIT_PROMPT_SEPARATOR"
-	  if [ "$GIT_STAGED" -ne "0" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_STAGED$GIT_STAGED$ResetColor"
-	  fi
+  if [[ -n "${GitStatus}" ]]; then
+    local Status="${Status} ${GIT_PROMPT_PREFIX}"
 
-	  if [ "$GIT_CONFLICTS" -ne "0" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_CONFLICTS$GIT_CONFLICTS$ResetColor"
-	  fi
-	  if [ "$GIT_CHANGED" -ne "0" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_CHANGED$GIT_CHANGED$ResetColor"
-	  fi
-	  if [ "$GIT_UNTRACKED" -ne "0" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_UNTRACKED$GIT_UNTRACKED$ResetColor"
-	  fi
-	  if [ "$GIT_CLEAN" -eq "1" ]; then
-		  STATUS="$STATUS$GIT_PROMPT_CLEAN"
-	  fi
-	  STATUS="$STATUS$ResetColor$GIT_PROMPT_SUFFIX"
+    Status="${Status}${GIT_PROMPT_BRANCH}${GitStatus[0]}${ResetColor}"
+    if [[ "${GitStatus[1]}" != "." ]]; then
+      Status="${Status}${GIT_PROMPT_REMOTE}${GitStatus[1]}${ResetColor}"
+    fi
 
-	  PS1="$PYTHON_VIRTUALENV$PROMPT_START$STATUS$PROMPT_END"
-	else
-	  PS1="$PROMPT_START$PROMPT_END"
-	fi
-}
+    Status="${Status}${GIT_PROMPT_SEPARATOR}"
+    if [[ "${GitStatus[2]}" -ne "0" ]]; then
+      Status="${Status}${GIT_PROMPT_STAGED}${GitStatus[2]}${ResetColor}"
+    fi
 
-# Determine active Python virtualenv details.
-function set_virtualenv () {
-  if test -z "$VIRTUAL_ENV" ; then
-      PYTHON_VIRTUALENV=""
+    if [[ "${GitStatus[3]}" -ne "0" ]]; then
+      Status="${Status}${GIT_PROMPT_CONFLICTS}${GitStatus[3]}${ResetColor}"
+    fi
+    if [[ "${GitStatus[4]}" -ne "0" ]]; then
+      Status="${Status}${GIT_PROMPT_CHANGED}${GitStatus[4]}${ResetColor}"
+    fi
+    if [[ "${GitStatus[5]}" -ne "0" ]]; then
+      Status="${Status}${GIT_PROMPT_UNTRACKED}${GitStatus[5]}${ResetColor}"
+    fi
+    if [[ "${GitStatus[6]}" -eq "1" ]]; then
+      Status="${Status}${GIT_PROMPT_CLEAN}${ResetColor}"
+    fi
+    Status="${Status}${GIT_PROMPT_SUFFIX}"
+
+    PS1="${PROMPT_START}${Status}${PROMPT_END}"
+    if [[ -n "${VIRTUAL_ENV}" ]]; then
+      local Blue="\[\033[1;34m\]"
+      PS1="${Blue}($(basename "${VIRTUAL_ENV}"))${ResetColor} ${PS1}"
+    fi
   else
-      PYTHON_VIRTUALENV="${BLUE}(`basename \"$VIRTUAL_ENV\"`)${ResetColor} "
+    PS1="${PROMPT_START}${PROMPT_END}"
   fi
 }
 


### PR DESCRIPTION
This commit prevent the pollution of the global namespace by using local variables (and a trick from bash: if a function declare a variable as local and call a function that modify that variable, then the local variable from the calling function is modified).

There is no other functional change, and the prompt is exactly the same.
