### PR TITLE
Use variable __GIT_STATUS_CMD instead of __GIT_PROMPT_DIR

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,6 +1,6 @@
-if [ "x$__GIT_PROMPT_DIR" == "x" ]
+if [ "x$__GIT_STATUS_CMD" == "x" ]
 then
-  __GIT_PROMPT_DIR=~/.bash
+  __GIT_STATUS_CMD=~/.bash/gitstatus.py
 fi
 
 # Colors
@@ -44,9 +44,8 @@ PROMPT_END=" \n$WHITE$Time12a$ResetColor $ "
 
 function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
-    local gitstatus="${__GIT_PROMPT_DIR}/gitstatus.py"
     
-    _GIT_STATUS=$(python $gitstatus)
+    _GIT_STATUS=$(python $__GIT_STATUS_CMD)
     __CURRENT_GIT_STATUS=($_GIT_STATUS)
 	GIT_BRANCH=${__CURRENT_GIT_STATUS[0]}
 	GIT_REMOTE=${__CURRENT_GIT_STATUS[1]}


### PR DESCRIPTION
Using variable __GIT_STATUS_CMD allow us to put gitstatus.py in easy way to whatever place on filesystem (as __GIT_PROMPT_DIR), but also allow us to rename script.

I need to not create any directory (~/.bash). It's easier to rename script to .gitstatus.py and put it in home directory.
