### PR TITLE
fixed problems when pre-set PROMPT_COMMAND has trailing semi-colon

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -176,6 +176,8 @@ fi
 if [ -z "$PROMPT_COMMAND" ]; then
   PROMPT_COMMAND=setGitPrompt
 else
+  PROMPT_COMMAND=${PROMPT_COMMAND%% }; # remove trailing spaces
+  PROMPT_COMMAND=${PROMPT_COMMAND%\;}; # remove trailing semi-colon
   PROMPT_COMMAND="$PROMPT_COMMAND;setGitPrompt"
 fi
 


### PR DESCRIPTION
There was a problem on my Mac where the PROMPT_COMMAND is set to 'update_terminal_cwd; ' (with a trailing space and a trailing semi-colon. This triggers a syntax error on the resulting double semi-colon.
The two line remove all trailing spaces and then all trailing semi-colons
