### PR TITLE
Run the async call and disown in the same subshell

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -110,8 +110,10 @@ function checkUpstream() {
   if [[ ! -e "${FETCH_HEAD}"  ||  -e `find "${FETCH_HEAD}" -mmin +${GIT_PROMPT_FETCH_TIMEOUT}` ]]
   then
     if [[ -n $(git remote show) ]]; then
-      async_run "git fetch --quiet"
-      disown -h
+      (
+        async_run "git fetch --quiet"
+        disown -h
+      )
     fi
   fi
 }


### PR DESCRIPTION
This suppresses the

[1]+ Done.

output, but I'm not confident enough in bash to know if there are other bad side-effects running the calls in a subshell.
