### PR TITLE
Fixed to work in Python 3.2/3.3

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -64,7 +64,7 @@ staged = str(nb_staged)
 conflicts = str(nb_U)
 changed = str(nb_changed)
 status_lines = Popen(['git','status','-s','-uall'],stdout=PIPE).communicate()[0].splitlines()
-untracked_lines = [a for a in status_lines if a.startswith("??")]
+untracked_lines = [a for a in map(lambda s: s.decode('utf-8'), status_lines) if a.startswith("??")]
 nb_untracked = len(untracked_lines)
 untracked = str(nb_untracked)
 stashes = Popen(['git','stash','list'],stdout=PIPE).communicate()[0].splitlines()
@@ -84,7 +84,7 @@ if not branch: # not on any branch
 	if tag: # if we are on a tag, print the tag's name
 		branch = tag
 	else:
-		branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0][:-1]
+		branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode('utf-8')[:-1]
 else:
 	remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].strip()
 	if remote_name:


### PR DESCRIPTION
In both Python 3.2 and 3.3.3 Popen.communicate() returns a tuple of bytes and some operations expects something of type str, this causes problems in two lines of the code (when showing the commit hash and when there are untracked files).

The proposed fix, solves this two issues and is tested in Python 2.6, 2.7, 3.2 and 3.3.3.

The exceptions raised were the following:

1 - If there are untracked files, it fails with the next message:

```
$ python3.2 ~/.gitprompt/gitstatus.py 
Traceback (most recent call last):
  File "/home/prog/.gitprompt/gitstatus.py", line 67, in <module>
    untracked_lines = [a for a in status_lines if a.startswith("??")]
  File "/home/prog/.gitprompt/gitstatus.py", line 67, in <listcomp>
    untracked_lines = [a for a in status_lines if a.startswith("??")]
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

2 - In "detached HEAD" mode:

```
$ python3.2 ~/.gitprompt/gitstatus.py Traceback (most recent call last):
  File "/home/prog/.gitprompt/gitstatus.py", line 83, in <module>
    branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0][:-1]
TypeError: Can't convert 'bytes' object to str implicitly
```
