### PR TITLE
fix VIRTUAL_ENV prompt outside a git repository

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -97,7 +97,11 @@ function git_prompt_config()
     PROMPT_END="${GIT_PROMPT_END}"
   fi
 
-  EMPTY_PROMPT="${PROMPT_START}$($prompt_callback)${PROMPT_END}"
+  if [[ -n "${VIRTUAL_ENV}" ]]; then
+    EMPTY_PROMPT="${Blue}($(basename "${VIRTUAL_ENV}"))${ResetColor} ${PROMPT_START}$($prompt_callback)${PROMPT_END}"
+  else
+    EMPTY_PROMPT="${PROMPT_START}$($prompt_callback)${PROMPT_END}"
+  fi
 
   # fetch remote revisions every other $GIT_PROMPT_FETCH_TIMEOUT (default 5) minutes
   GIT_PROMPT_FETCH_TIMEOUT=${1-5}


### PR DESCRIPTION
VIRTUAL_ENV is not honored outside a git repository.
