### PR TITLE
Add config variable to toggle leading space in front of Git Prompt

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -97,6 +97,13 @@ function git_prompt_config()
     PROMPT_END="${GIT_PROMPT_END}"
   fi
 
+  # set GIT_PROMPT_LEADING_SPACE to 0 if you want to have no leading space in front of the GIT prompt
+  if [ "x${GIT_PROMPT_LEADING_SPACE}" == "x0" ]; then
+    PROMPT_LEADING_SPACE=""
+  else
+    PROMPT_LEADING_SPACE=" "
+  fi
+
   if [[ -n "${VIRTUAL_ENV}" ]]; then
     EMPTY_PROMPT="${Blue}($(basename "${VIRTUAL_ENV}"))${ResetColor} ${PROMPT_START}$($prompt_callback)${PROMPT_END}"
   else
@@ -166,6 +173,7 @@ function updatePrompt() {
   local GIT_PROMPT_UNTRACKED
   local GIT_PROMPT_STASHED
   local GIT_PROMPT_CLEAN
+  local PROMPT_LEADING_SPACE
   local PROMPT_START
   local PROMPT_END
   local EMPTY_PROMPT
@@ -192,7 +200,7 @@ function updatePrompt() {
   local GIT_CLEAN=${GitStatus[7]}
 
   if [[ -n "${GitStatus}" ]]; then
-    local STATUS=" ${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}${GIT_BRANCH}${ResetColor}"
+    local STATUS="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}${GIT_BRANCH}${ResetColor}"
 
     if [[ -n "${GIT_REMOTE}" ]]; then
       STATUS="${STATUS}${GIT_PROMPT_REMOTE}${GIT_REMOTE}${ResetColor}"


### PR DESCRIPTION
Set GIT_PROMPT_LEADING_SPACE to 0 if you do not want a leading space in
front of the prompt. If not set or to any other value a leading space is
printed out.
