### PR TITLE
fix branch name.

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -16,7 +16,7 @@ gitsym=`git symbolic-ref HEAD`
 case "$gitsym" in fatal*) exit 0 ;; esac
 
 # the current branch is the tail end of the symbolic reference
-branch="${gitsym##*/}"    # get the basename after "refs/head/"
+branch="${gitsym##refs/heads/}"    # get the basename after "refs/heads/"
 
 tmp="/tmp/$$-gitstatus.out"
 trap "rm -f \"$tmp\"" EXIT


### PR DESCRIPTION
branches can have '/'. So, just remove the 'refs/heads' prefix.
