### PR TITLE
Adds support to show Conda environment on prompt

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -134,6 +134,8 @@ function git_prompt_config()
   else
     if [[ -n "${VIRTUAL_ENV}" ]]; then
       EMPTY_PROMPT="(${Blue}$(basename "${VIRTUAL_ENV}")${ResetColor}) ${PROMPT_START}$($prompt_callback)${PROMPT_END}"
+    elif [[ -n "${CONDA_DEFAULT_ENV}" ]]; then
+      EMPTY_PROMPT="(${Blue}$(basename "${CONDA_DEFAULT_ENV}")${ResetColor}) ${PROMPT_START}$($prompt_callback)${PROMPT_END}"
     else
       EMPTY_PROMPT="${PROMPT_START}$($prompt_callback)${PROMPT_END}"
     fi
@@ -266,6 +268,10 @@ function updatePrompt() {
     PS1="${PROMPT_START}$($prompt_callback)${STATUS}${PROMPT_END}"
     if [[ -n "${VIRTUAL_ENV}" ]]; then
       PS1="(${Blue}$(basename ${VIRTUAL_ENV})${ResetColor}) ${PS1}"
+    fi
+
+    if [[ -n "${CONDA_DEFAULT_ENV}" ]]; then
+      PS1="(${Blue}$(basename ${CONDA_DEFAULT_ENV})${ResetColor}) ${PS1}"
     fi
 
   else


### PR DESCRIPTION
When one uses a Virtualenv environment, its name is shown in the prompt.
The same did not happen with a Conda environment. This fix it.
