### PR TITLE
Fix an error when opening a new tab from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The symbols are as follows:
    GIT_PROMPT_ONLY_IN_REPO=1
 
    # as last entry source the gitprompt script
-   source .bash-git-prompt/gitprompt.sh
+   source ~/.bash-git-prompt/gitprompt.sh
 ```
 
 - Go in a git repository and test it!


### PR DESCRIPTION
When I open a new tab from a terminal where the current path is not $HOME I get the following error :

```
bash: .bash-git-prompt/gitprompt.sh: No such file or directory
```
