### PR TITLE
Modify gitstatus.sh to detect local branch without tracking remote

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -111,6 +111,15 @@ else
     remote_ref="refs/remotes/$remote_name/${merge_name##refs/heads/}"
   fi
 
+  # detect if the local branch have a remote tracking branch
+  cmd_output=$(git rev-parse --abbrev-ref ${branch}@{upstream} 2>&1 >/dev/null)
+
+  if [ `count_lines "$cmd_output" "fatal: No upstream"` == 1 ] ; then
+    has_remote_tracking=0
+  else
+    has_remote_tracking=1
+  fi
+
   # get the revision list, and count the leading "<" and ">"
   revgit=`git rev-list --left-right ${remote_ref}...HEAD`
   num_revs=`all_lines "$revgit"`
@@ -123,9 +132,14 @@ else
     remote="${remote}${symbols_ahead}${num_ahead}"
   fi
 fi
+
 if [[ -z "$remote" ]] ; then
   remote='.'
 fi
+
+if [[ "$has_remote_tracking" == "0" ]] ; then
+  remote='L'
+fi 
 
 for w in "$branch" "$remote" $num_staged $num_conflicts $num_changed $num_untracked $num_stashed $clean ; do
   echo "$w"


### PR DESCRIPTION
This a Pull Request to add a feature in gitstatus.sh script to detect if the current branch have a remote tracking one. I think it's an useful feature because it's common to forget to do the first push of a branch, and when that happens the prompt doesn't show any commit behind or ahead. So maybe you think you are "in sync" with the remote, but the truth is that no remote tracking branch exists 
