### PR TITLE
Please consider add a new Git consistent color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ from scratch by following this procedure:
 * Run the following command to create a tarball:
 
 ````sh
-    VER=$(git describe)
+    VER=$(git describe --tags)
     # replace dash with underscore to work around
     # rpmbuild does not allow dash in version string
     VER=${VER//\-/_}
@@ -270,6 +270,7 @@ from scratch by following this procedure:
         HEAD                                   \
         --  *.sh                               \
             *.py                               \
+            *.rb                               \
             *.fish                             \
             README.md                          \
             themes                             \

--- a/bash-git-prompt.spec
+++ b/bash-git-prompt.spec
@@ -60,7 +60,8 @@ if [ -f %{_datadir}/%{name}/gitprompt.sh ]; then
     # Set config variables first
 
     GIT_PROMPT_ONLY_IN_REPO=1
-    GIT_PROMPT_THEME=Default
+    GIT_PROMPT_THEME=Solarized_Git
+    GIT_PROMPT_FETCH_REMOTE_STATUS=0
     source %{_datadir}/%{name}/gitprompt.sh
 fi
 %{END_TOKEN}
@@ -72,5 +73,7 @@ sed -i -e '/^%{START_TOKEN}/, /^%{END_TOKEN}/{d}' /etc/bashrc
 
 
 %changelog
-* Fri Aug 08 2014 Justin Zhang <schnell18@gmail.com - 1.0.1-1
+* Fri Nov 21 2014 Justin Zhang <schnell18@gmail.com> - 2.3.4-1
+- Add custom theme Solarized Git to show colors in Git way
+* Fri Aug 08 2014 Justin Zhang <schnell18@gmail.com> - 1.0.1-1
 - Initial version of package

--- a/themes/Solarized_Git.bgptheme
+++ b/themes/Solarized_Git.bgptheme
@@ -1,0 +1,17 @@
+# This theme for gitprompt.sh is optimized for the "Solarized Dark" and
+# "Solarized Light" color schemes tweaked for Ubuntu terminal fonts.
+# It use the use scheme which is consisent with Git.
+
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Solarized Git"
+  GIT_PROMPT_CONFLICTS="${Red}✖ "
+  GIT_PROMPT_CHANGED="${Red}✚ "
+  GIT_PROMPT_UNTRACKED="${Red}…"
+  GIT_PROMPT_STAGED="${Green}●"
+  GIT_PROMPT_STASHED="${BoldMagenta}⚑ "
+  GIT_PROMPT_CLEAN="${Green}✔"
+  GIT_PROMPT_END_USER=" \n${BoldBlue}${Time12a}${ResetColor} $ "
+  GIT_PROMPT_END_ROOT=" \n${BoldBlue}${Time12a}${ResetColor} # "
+}
+
+reload_git_prompt_colors "Solarized Git"


### PR DESCRIPTION
Hi,
  I'm glad to see this bash-git-prompt project is being actively maintained and continue to deliver values.

  However, I'd like to have color scheme which is consistent w/ the one used by Git. That is:
 
1. show number of untracked, conflicted and modified files in red
2. show number of staged files in green

Since user not only uses the number indicated by the prompt but also need drill down to the specific files, if base-git-prompt display default color scheme uses different color than the Git built-in, it confuses user.

This PR is intended to implement this idea in the additional "Solarized_Git" theme.