### PR TITLE
Added openSUSE themes

### DIFF
--- a/themes/Single_line_NoExitState_openSUSE.bgptheme
+++ b/themes/Single_line_NoExitState_openSUSE.bgptheme
@@ -1,0 +1,19 @@
+# This is a theme for gitprompt.sh,
+# it uses the default openSUSE bash prompt style
+
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Single_line_NoExitState_openSUSE"
+  GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
+  GIT_PROMPT_CHANGED="${Yellow}✚ "
+  GIT_PROMPT_STAGED="${Magenta}●"
+
+  GIT_PROMPT_START_USER="\u@\h:\w"
+  GIT_PROMPT_START_ROOT="${BoldRed}\h:\w"
+
+  GIT_PROMPT_END_USER="> "
+  GIT_PROMPT_END_ROOT=" # ${ResetColor}"
+}
+
+reload_git_prompt_colors "Single_line_NoExitState_openSUSE"
+

--- a/themes/Single_line_openSUSE.bgptheme
+++ b/themes/Single_line_openSUSE.bgptheme
@@ -1,0 +1,19 @@
+# This is a theme for gitprompt.sh,
+# it uses the default openSUSE bash prompt style with exit status
+
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Single_line_openSUSE"
+  GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
+  GIT_PROMPT_CHANGED="${Yellow}✚ "
+  GIT_PROMPT_STAGED="${Magenta}●"
+
+  GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${ResetColor}\u@\h:\w"
+  GIT_PROMPT_START_ROOT="_LAST_COMMAND_INDICATOR_ ${BoldRed}\h:\w"
+
+  GIT_PROMPT_END_USER="${ResetColor}> "
+  GIT_PROMPT_END_ROOT=" # ${ResetColor}"
+}
+
+reload_git_prompt_colors "Single_line_openSUSE"
+


### PR DESCRIPTION
Hi,

I tried `bash-git-prompt` in openSUSE distribution, works nice, but the default theme is too different to the standard openSUSE bash prompt style.

I found out that defining a new style is really easy so I created two styles which mimic the default openSUSE prompt style.

Thank you!