### PR TITLE
_LAST_COMMAND_INDICATOR_ now displays symbolic names of signals

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -185,6 +185,24 @@ git_prompt_reset() {
   done
 }
 
+# gp_format_exit_status RETVAL
+#
+# echos the symbolic signal name represented by RETVAL if the process was 
+# signalled, otherwise echos the original value of RETVAL
+
+gp_format_exit_status() {
+    local RETVAL="$1"
+    local SIGNAL
+    # Suppress STDERR in case RETVAL is not an integer (in such cases, RETVAL 
+    # is echoed verbatim)
+    if [ "${RETVAL}" -gt 128 ] 2>/dev/null; then
+        SIGNAL=$(( ${RETVAL} - 128 ))
+        kill -l "${SIGNAL}" 2>/dev/null || echo "${RETVAL}"
+    else
+        echo "${RETVAL}"
+    fi
+}
+
 function git_prompt_config()
 {
   #Checking if root to change output
@@ -214,6 +232,7 @@ function git_prompt_config()
   fi
 
   # replace _LAST_COMMAND_STATE_ token with the actual state
+  GIT_PROMPT_LAST_COMMAND_STATE=$(gp_format_exit_status ${GIT_PROMPT_LAST_COMMAND_STATE})
   LAST_COMMAND_INDICATOR="${LAST_COMMAND_INDICATOR//_LAST_COMMAND_STATE_/${GIT_PROMPT_LAST_COMMAND_STATE}}"
 
   # Do this only once to define PROMPT_START and PROMPT_END


### PR DESCRIPTION
Found myself wandering which signal exit status 141 was, and after toying with the arithmetic to discover it was signal 13 then had to look up the symbolic name for this to discover it was SIGPIPE. Figured it would be nice if the prompt that showed me the number did the leg work for me.

As it happens, the BASH builtin `kill` can actually translate a number into a symbolic name natively, which means this patch should be portable between Linux / BSD / OSX where signal numbers may vary. My testing on OSX (10.10) and Linux (3.2) has shown it to be useful and, thus far, correct.