### PR TITLE
get_prompt_help() failed sourcing themes/Default.bgptheme,

### DIFF
--- a/git-prompt-help.sh
+++ b/git-prompt-help.sh
@@ -4,7 +4,7 @@
 
 git_prompt_help() {
   source ${__GIT_PROMPT_DIR}/prompt-colors.sh
-  source themes/Default.bgptheme
+  source ${__GIT_PROMPT_DIR}/themes/Default.bgptheme
  cat <<EOF | sed 's/\\\[\\033//g' | sed 's/\\\]//g'
 The git prompt format is [<BRANCH><TRACKING>|<LOCALSTATUS>]
 


### PR DESCRIPTION
 unless called from the bash-git-prompt directory.  Fixed by adding "{__GIT_PROMPT_DIR}/".

(This pull request replaces #131, where I pushed a second change while there was a pending pull request.)