### PR TITLE
Fix Solaris compatibility

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -3,7 +3,7 @@
 function async_run()
 {
   {
-    $1 &> /dev/null
+    eval "$@" &> /dev/null
   }&
 }
 
@@ -357,13 +357,55 @@ function setGitPrompt() {
   updatePrompt
 }
 
+# some versions of find do not have -mmin
+_have_find_mmin=1
+
+function olderThanMinutes() {
+    local matches
+    local find_exit_code
+
+    if [[ -z "$_find_command" ]]; then
+        if command -v gfind > /dev/null; then
+            _find_command=gfind
+        else
+            _find_command=find
+        fi
+    fi
+
+    if [[ "$_have_find_mmin" = 1 ]]; then
+        matches=`"$_find_command" "$1" -mmin +"$2" 2> /dev/null`
+        find_exit_code="$?"
+        if [[ -n "$matches" ]]; then
+            return 0
+        else
+            if [[ "$find_exit_code" != 0 ]]; then
+                _have_find_mmin=0
+            else
+                return 1
+            fi
+        fi
+    fi
+
+    # try perl, solaris ships with perl
+    if command -v perl > /dev/null; then
+        perl -e '((time - (stat("'"$1"'"))[9]) / 60) > '"$2"' && exit(0) || exit(1)'
+        return "$?"
+    else
+        echo >&2
+        echo "[1;31mWARNING[0m: neither a find that supports -mmin (such as GNU find) or perl is available, disabling remote status checking. Install GNU find as gfind or perl to enable this feature, or set GIT_PROMPT_FETCH_REMOTE_STATUS=0 to disable this warning." >&2
+        echo >&2
+        GIT_PROMPT_FETCH_REMOTE_STATUS=0
+        return 1
+    fi
+}
+
 function checkUpstream() {
   local GIT_PROMPT_FETCH_TIMEOUT
   git_prompt_config
 
   local FETCH_HEAD="$repo/.git/FETCH_HEAD"
   # Fech repo if local is stale for more than $GIT_FETCH_TIMEOUT minutes
-  if [[ ! -e "$FETCH_HEAD"  ||  -e `find "$FETCH_HEAD" -mmin +$GIT_PROMPT_FETCH_TIMEOUT` ]]
+  if [[ ! -e "$FETCH_HEAD" ]] || olderThanMinutes "$FETCH_HEAD" "$GIT_PROMPT_FETCH_TIMEOUT"
   then
     if [[ -n $(git remote show) ]]; then
       (

--- a/themes/Crunch.bgptheme
+++ b/themes/Crunch.bgptheme
@@ -5,7 +5,7 @@ override_git_prompt_colors() {
   if [ -e ~/.rvm/bin/rvm-prompt ]; then
     RUBY_PROMPT='{$(~/.rvm/bin/rvm-prompt i v)}'
   else
-    if which rbenv &> /dev/null; then
+    if command -v rbenv > /dev/null; then
       RUBY_PROMPT='{$(rbenv version | sed -e "s/ (set.*$//")}'
     fi
   fi

--- a/themes/Solarized_Extravagant.bgptheme
+++ b/themes/Solarized_Extravagant.bgptheme
@@ -7,7 +7,7 @@ override_git_prompt_colors() {
   if [ -e ~/.rvm/bin/rvm-prompt ]; then
     RUBY_PROMPT='{$(~/.rvm/bin/rvm-prompt i v)}'
   else
-    if which rbenv &> /dev/null; then
+    if command -v rbenv > /dev/null; then
       RUBY_PROMPT='{$(rbenv version | sed -e "s/ (set.*$//")}'
     fi
   fi


### PR DESCRIPTION
Add a workaround for the lack of -mmin in Solarises find, check for
gfind from opencsw and failing that use perl, which Solaris ships with
and is widely available on many other systems.

Use eval in async_run to run the command, the old bash in Solaris 5.10
does not recognize the previous syntax.

Use command -v instead of which to check for the existance of rbenv in
the Crunch and Solarized_Extravagant themes. command -v is the POSIX-ly
correct way to check for the existance of a command, and which does not
set the exit code on Solaris.