### PR TITLE
Spec file tried to include non-existent python files

### DIFF
--- a/bash-git-prompt.spec
+++ b/bash-git-prompt.spec
@@ -31,7 +31,7 @@ rm -rf %{buildroot}
 
 install -d 755 %{buildroot}%{_datadir}/%{name}
 install -pm 755 *.sh %{buildroot}%{_datadir}/%{name}
-install -pm 755 *.py %{buildroot}%{_datadir}/%{name}
+#install -pm 755 *.py %{buildroot}%{_datadir}/%{name}
 install -pm 755 *.fish %{buildroot}%{_datadir}/%{name}
 install -pm 644 README.md %{buildroot}%{_datadir}/%{name}
 install -d 755 %{buildroot}%{_datadir}/%{name}/themes
@@ -39,8 +39,8 @@ install -pm 644 themes/*.bgptheme %{buildroot}%{_datadir}/%{name}/themes
 install -pm 644 themes/*.bgptemplate %{buildroot}%{_datadir}/%{name}/themes
 
 # never include compiled Python program
-rm -fr  %{buildroot}%{_datadir}/%{name}/*.pyo
-rm -fr  %{buildroot}%{_datadir}/%{name}/*.pyc
+#rm -fr  %{buildroot}%{_datadir}/%{name}/*.pyo
+#rm -fr  %{buildroot}%{_datadir}/%{name}/*.pyc
 
 
 %clean


### PR DESCRIPTION
The spec file needed the install *.py line to be commented out in order to work.
