### PR TITLE
Simplify branch name extraction

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -19,13 +19,10 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-gitsym=`git symbolic-ref HEAD`
+branch=`git symbolic-ref HEAD --short`
 
 # if "fatal: Not a git repo .., then exit
-case "$gitsym" in fatal*) exit 0 ;; esac
-
-# the current branch is the tail end of the symbolic reference
-branch="${gitsym##refs/heads/}"    # get the basename after "refs/heads/"
+case "$branch" in fatal*) exit 0 ;; esac
 
 gitstatus=`git diff --name-status 2>&1`
 


### PR DESCRIPTION
Use symbolic-ref --short to get the branch name without the refs/heads

Signed-off-by: Roy Golan <rgolan@redhat.com>