### PR TITLE
fix match for theme

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -52,7 +52,7 @@ function get_theme()
       local theme=""
       
       # use default theme, if theme was not found
-      for themefile in `ls "$__GIT_PROMPT_DIR/themes"`; do
+      for themefile in $(cd "$__GIT_PROMPT_DIR/themes" && echo *); do
         if [[ "${themefile}" = "${GIT_PROMPT_THEME}.bgptheme" ]]; then
           theme=$GIT_PROMPT_THEME
         fi


### PR DESCRIPTION
bash-git-prompt did not work for me on ubuntu while it does work on osx. The reason seems to be that in interactive shells, ls is aliased to ls --colors on ubuntu. This causes the matching for themes to fail.

This patch fixes that problem by changing how the matching works.