### PR TITLE
Extremelly minor change to installation README.md for OS-X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ staged, changed, etc.
 
 # ATTENTION! Breaking changes!
 
-**If you use this prompt already, please update your `.git-prompt-colors.sh`, 
+**If you use this prompt already, please update your `.git-prompt-colors.sh`,
 if you have one. It now contains a function named `define_git_prompt_colors()` or `override_git_prompt_colors()`!**
 
 **Please see the ``Custom.bgptemplate`` in the ``themes`` subdirectory of the installation directory!**
@@ -24,7 +24,7 @@ and call the function `reload_git_prompt_colors <ThemeName>` like follows:**
 ```sh
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Custom" # needed for reload optimization, should be unique
-  
+
   # Place your overrides here
   ...
 }
@@ -37,7 +37,7 @@ The advantage of this approach is, that you only need to specify the parts, that
 
 ---
 
-**The variable `GIT_PROMPT_SHOW_LAST_COMMAND_INDICATOR` was replaced with a more general placeholder 
+**The variable `GIT_PROMPT_SHOW_LAST_COMMAND_INDICATOR` was replaced with a more general placeholder
 named ``_LAST_COMMAND_INDICATOR_``, which is replaced by the state of the last executed command. It is now activated by default.**
 
 ## Examples
@@ -83,10 +83,10 @@ The symbols are as follows:
 
 - Run `brew update`
 
-- Run `brew install bash-git-prompt` for the last stable release or `brew install --HEAD bash-git-prompt` for the 
+- Run `brew install bash-git-prompt` for the last stable release or `brew install --HEAD bash-git-prompt` for the
    latest version directly from the repository
 
-- Now you can source the file in your `~/.bashrc` as follows:
+- Now you can source the file in your `~/.bash_profile` as follows:
 
 ```sh
 if [ -f "$(brew --prefix)/opt/bash-git-prompt/share/gitprompt.sh" ]; then
@@ -114,7 +114,7 @@ git clone https://github.com/magicmonty/bash-git-prompt.git .bash-git-prompt
 
    # Set config variables first
    GIT_PROMPT_ONLY_IN_REPO=1
-   
+
    # GIT_PROMPT_FETCH_REMOTE_STATUS=0   # uncomment to avoid fetching remote status
 
    # GIT_PROMPT_START=...    # uncomment for custom prompt start sequence
@@ -138,7 +138,7 @@ GIT_PROMPT_THEME=Solarized
 ```
 
 If you set `GIT_PROMPT_THEME` to `Custom`, then the `.git-prompt-colors.sh` in the home directory will be used.
-This file can now be generated with the command `git_prompt_make_custom_theme [<Name of base theme>]`. If the name of 
+This file can now be generated with the command `git_prompt_make_custom_theme [<Name of base theme>]`. If the name of
 the base theme is ommitted or the theme file is not found, then the Default theme is used. If you have already a custom
 `.git-prompt-colors.sh` in your home directory, a error message will be shown.
 
@@ -157,7 +157,7 @@ A theme consists of a function `override_git_prompt_colors()` which defines at l
 ```sh
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Custom" # needed for reload optimization, should be unique
-  
+
   # Place your overrides here
   ...
 }
@@ -203,7 +203,7 @@ function prompt_callback {
 
 - There is an indicator at the start of the prompt, which shows
   the result of the last executed command by if you put the placeholder
-  `_LAST_COMMAND_INDICATOR_` in any of the prompt templates. 
+  `_LAST_COMMAND_INDICATOR_` in any of the prompt templates.
   It is now by default activated in the default theme:
 
 ```sh
@@ -218,7 +218,7 @@ function prompt_callback {
 ```sh
 GIT_PROMPT_COMMAND_OK="${Green}✔ " # displays as ✔
 GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_ " # displays as ✘-1 for exit code 1
-``` 
+```
 
 - It is now possible to disable the fetching of the remote repository either
   globally by setting ``GIT_PROMPT_FETCH_REMOTE_STATUS=0`` in your .bashrc or


### PR DESCRIPTION
Change .bashrc to .bash_profile since it is the standard file to use for startup w/ latest OS-X.

Also Atom editor removed the white space at end of sentences. That's what the rest of those changes are in the file. Hope that isn't an issue.

Cheers