### PR TITLE
Check if prompt_callback is a function must occur after theme has loa…

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -225,6 +225,12 @@ function git_prompt_config()
 
   git_prompt_load_theme
 
+  if [ "`type -t prompt_callback`" = 'function' ]; then
+      prompt_callback="prompt_callback"
+  else
+      prompt_callback="prompt_callback_default"
+  fi
+
   if [ $GIT_PROMPT_LAST_COMMAND_STATE = 0 ]; then
     LAST_COMMAND_INDICATOR="$GIT_PROMPT_COMMAND_OK";
   else
@@ -523,12 +529,6 @@ function prompt_callback_default {
 }
 
 function gp_install_prompt {
-  if [ "`type -t prompt_callback`" = 'function' ]; then
-      prompt_callback="prompt_callback"
-  else
-      prompt_callback="prompt_callback_default"
-  fi
-
   if [ -z "$OLD_GITPROMPT" ]; then
     OLD_GITPROMPT=$PS1
   fi


### PR DESCRIPTION
…ded if theme is to override `prompt_callback`

I noticed that the check if  `prompt-callback` is a function occurs only once and before the theme is loaded, thus a theme can never override `prompt_callback`.

I don't know if there is a case where the original check would be needed, so I just moved it until after loading the theme.

This should fix issue #156