### PR TITLE
Changed language depending test for upstream to use return code instead.

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -78,10 +78,10 @@ else
   # detect if the local branch have a remote tracking branch
   cmd_output=$(git rev-parse --abbrev-ref ${branch}@{upstream} 2>&1 >/dev/null)
 
-  if [ `count_lines "$cmd_output" "fatal: no upstream"` == 1 ] ; then
-    has_remote_tracking=0
-  else
+  if [[ $? == 0 ]]; then
     has_remote_tracking=1
+  else
+    has_remote_tracking=0
   fi
 
   # get the revision list, and count the leading "<" and ">"


### PR DESCRIPTION
The check for upstream branch existence is language dependent.

I changed it to use return code from the command instead.

My Swedish locale gives this result:
```bash
git rev-parse --abbrev-ref ${branch}@{upstream} 2>&1 >/dev/null
fatal: Ingen standarduppström angiven för grenen "nisse"
```