### PR TITLE
Fix for Ubuntu Mono fonts; added a space for symbols overlapping next char

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The prompt may look like the following:
 
 ![Example prompt](gitprompt.png)
 
-* ``(master↑3|✚1)``: on branch ``master``, ahead of remote by 3 commits, 1 file changed but not staged
-* ``(status|●2)``: on branch ``status``, 2 files staged
-* ``(master|✚7…)``: on branch ``master``, 7 files changed, some files untracked
-* ``(master|✖2✚3)``: on branch ``master``, 2 conflicts, 3 files changed
-* ``(master|⚑2)``: on branch ``master``, 2 stash entries
-* ``(experimental↓2↑3|✔)``: on branch ``experimental``; your branch has diverged by 3 commits, remote by 2 commits; the repository is otherwise clean
+* ``(master↑ 3|✚ 1)``: on branch ``master``, ahead of remote by 3 commits, 1 file changed but not staged
+* ``(status|● 2)``: on branch ``status``, 2 files staged
+* ``(master|✚ 7…)``: on branch ``master``, 7 files changed, some files untracked
+* ``(master|✖ 2 ✚ 3)``: on branch ``master``, 2 conflicts, 3 files changed
+* ``(master|⚑ 2)``: on branch ``master``, 2 stash entries
+* ``(experimental↓ 2 ↑ 3|✔)``: on branch ``experimental``; your branch has diverged by 3 commits, remote by 2 commits; the repository is otherwise clean
 * ``(:70c2952|✔)``: not on any branch; parent commit has hash ``70c2952``; the repository is otherwise clean
 
 ##  Prompt Structure
@@ -66,15 +66,15 @@ The symbols are as follows:
 
 - Local Status Symbols
   - ``✔``: repository clean
-  - ``●n``: there are ``n`` staged files
-  - ``✖n``: there are ``n`` files with merge conflict(s)
-  - ``✚n``: there are ``n`` changed but *unstaged* files
+  - ``● n``: there are ``n`` staged files
+  - ``✖ n``: there are ``n`` files with merge conflict(s)
+  - ``✚ n``: there are ``n`` changed but *unstaged* files
   - ``…n``: there are ``n`` untracked files
-  - ``⚑n``: there are ``n`` stash entries
+  - ``⚑ n``: there are ``n`` stash entries
 - Branch Tracking Symbols
-  - ``↑n``: ahead of remote by ``n`` commits
-  - ``↓n``: behind remote by ``n`` commits
-  - ``↓m↑n``: branches diverged, other by ``m`` commits, yours by ``n`` commits
+  - ``↑ n``: ahead of remote by ``n`` commits
+  - ``↓ n``: behind remote by ``n`` commits
+  - ``↓ m ↑ n``: branches diverged, other by ``m`` commits, yours by ``n`` commits
   - ``L``: local branch, not remotely tracked
 - Branch Symbol:<br />
   	When the branch name starts with a colon ``:``, it means it's actually a hash, not a branch (although it should be pretty clear, unless you name your branches like hashes :-)

--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -42,7 +42,7 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR="|"; fi              # separates each item
 
   if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}● "; fi           # the number of staged files/directories
   if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
   if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
 

--- a/themes/Single_line.bgptheme
+++ b/themes/Single_line.bgptheme
@@ -42,7 +42,7 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR="|"; fi           # separates each item
 
   if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}● "; fi           # the number of staged files/directories
   if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi    # the number of files in conflict
   if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi       # the number of changed files
 

--- a/themes/Single_line_NoExitState_openSUSE.bgptheme
+++ b/themes/Single_line_NoExitState_openSUSE.bgptheme
@@ -6,7 +6,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="\u@\h:\w"
   GIT_PROMPT_START_ROOT="${BoldRed}\h:\w"

--- a/themes/Single_line_Solarized.bgptheme
+++ b/themes/Single_line_Solarized.bgptheme
@@ -45,7 +45,7 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR=" |"; fi           # separates each item
 
   if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi                   # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Yellow}●${ResetColor}"; fi        # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Yellow}● ${ResetColor}"; fi        # the number of staged files/directories
   if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"; fi # the number of files in conflict
   if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"; fi    # the number of changed files
 

--- a/themes/Single_line_Ubuntu.bgptheme
+++ b/themes/Single_line_Ubuntu.bgptheme
@@ -43,7 +43,7 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR=" |"; fi           # separates each item
 
   if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi                   # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Red}●${ResetColor}"; fi        # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Red}● ${ResetColor}"; fi        # the number of staged files/directories
   if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"; fi # the number of files in conflict
   if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"; fi    # the number of changed files
 

--- a/themes/Single_line_openSUSE.bgptheme
+++ b/themes/Single_line_openSUSE.bgptheme
@@ -6,7 +6,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${ResetColor}\u@\h:\w"
   GIT_PROMPT_START_ROOT="_LAST_COMMAND_INDICATOR_ ${BoldRed}\h:\w"

--- a/themes/Solarized.bgptheme
+++ b/themes/Solarized.bgptheme
@@ -3,7 +3,7 @@
 
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Solarized"
-  GIT_PROMPT_STAGED="${Yellow}●"
+  GIT_PROMPT_STAGED="${Yellow}● "
   GIT_PROMPT_STASHED="${BoldMagenta}⚑ "
   GIT_PROMPT_CLEAN="${Green}✔"
   GIT_PROMPT_END_USER=" \n${BoldBlue}${Time12a}${ResetColor} $ "


### PR DESCRIPTION
When using the Ubuntu Mono fonts (one of the best terminal fonts out there), any char next to ● is almost invisible. See the screenshot to see what I mean.

The fix is to add an extra space after ●
![screenshot from 2015-09-27 21-14-35](https://cloud.githubusercontent.com/assets/1625934/10122530/b67f1ce8-655f-11e5-9c94-786d8b231cc3.png)
