### PR TITLE
Fixed bug where not all untracked files in folders were shown

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -15,7 +15,7 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-gitstatus=$( LC_ALL=C git status --porcelain --branch )
+gitstatus=$( LC_ALL=C git status --untracked-files=all --porcelain --branch )
 
 # if the status is fatal, exit now
 [[ "$?" -ne 0 ]] && exit 0


### PR DESCRIPTION
The old version of gitstatus.sh counted all untracked files, even in subdirectories. This patch makes the new one behave like the old one, i.e. shows all untracked file count.