### PR TITLE
Use portable shebang

### DIFF
--- a/git-prompt-help.sh
+++ b/git-prompt-help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #  git-prompt-help -- show useful info to help new users with the information
 # being displayed.
 

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function async_run() {
   {

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- coding: UTF-8 -*-
 # gitstatus.sh -- produce the current git repo status on STDOUT
 # Functionally equivalent to 'gitstatus.py', but written in bash (not python).

--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- coding: UTF-8 -*-
 # gitstatus.sh -- produce the current git repo status on STDOUT
 # Functionally equivalent to 'gitstatus.py', but written in bash (not python).


### PR DESCRIPTION
Had hard time to make bash-git-prompt work with nixos where bash is not in /bin/bash. This was enough to make prompt work.