### PR TITLE
Bugfix - reverted command to check if in repo and extract branch. Now…

### DIFF
--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -19,14 +19,12 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-branch=$( git rev-parse --abbrev-ref HEAD )
+gitsym=$( git symbolic-ref HEAD 2>/dev/null )
 
-#If error code we are not in a repo - exit
-if [[ $? != 0 ]]; then exit 0; fi
-
-#If we are detached, branch name will be HEAD
-if [[ "$branch" == "HEAD" ]]; then
-  unset branch
+#If exit status OK, we have a branch
+if [[ $? == 0 ]]; then
+  # the current branch is the tail end of the symbolic reference
+  branch="${gitsym##refs/heads/}"    # get the basename after "refs/heads/"
 fi
 
 gitstatus=$( git diff --name-status 2>&1 )


### PR DESCRIPTION
… works for tags and commit checkouts

The original version exited prematurely when on tag or commit checkout, but my replacement had other problems..