### PR TITLE
Themes overriding define_undefined_git_prompt_colors needs the new variables

### DIFF
--- a/themes/Single_line.bgptheme
+++ b/themes/Single_line.bgptheme
@@ -60,10 +60,22 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_COMMAND_OK} ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔"; fi    # indicator if the last command returned with an exit code of 0
   if [[ -z ${GIT_PROMPT_COMMAND_FAIL} ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘"; fi  # indicator if the last command returned with an exit code of other than 0
 
+  # Possible to change which command is used to create git status information
+  # There are three options:
+  # 1) gitstatus.sh (uses git status --branch --porcelain - fast, requires git > 1.7.10)
+  # 2) gitstatus_pre-1.7.10.sh (Uses a variety of git commands and pipes - slower, works with older git clients)
+  # 3) gitstatus.py (Unsupported, lack features found in the bash versions)
+  if [[ -z ${GIT_PROMPT_STATUS_COMMAND} ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
+
   # template for displaying the current virtual environment
   # use the placeholder _VIRTUALENV_ will be replaced with
   # the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)
   if [[ -z ${GIT_PROMPT_VIRTUALENV} ]]; then GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "; fi
+
+  # template for displaying the current remote tracking branch
+  # use the placeholder _UPSTREAM_ will be replaced with
+  # the name of the current remote tracking branch
+  if [[ -z ${GIT_PROMPT_UPSTREAM} ]]; then GIT_PROMPT_UPSTREAM=" {${Blue}_UPSTREAM_${ResetColor}}"; fi
 
   # _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
   if [[ -z ${GIT_PROMPT_START_USER} ]]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${BoldYellow}${PathShort}${ResetColor}"; fi

--- a/themes/Single_line_Solarized.bgptheme
+++ b/themes/Single_line_Solarized.bgptheme
@@ -63,6 +63,13 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_COMMAND_OK} ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔"; fi    # indicator if the last command returned with an exit code of 0
   if [[ -z ${GIT_PROMPT_COMMAND_FAIL} ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘"; fi  # indicator if the last command returned with an exit code of other than 0
 
+  # Possible to change which command is used to create git status information
+  # There are three options:
+  # 1) gitstatus.sh (uses git status --branch --porcelain - fast, requires git > 1.7.10)
+  # 2) gitstatus_pre-1.7.10.sh (Uses a variety of git commands and pipes - slower, works with older git clients)
+  # 3) gitstatus.py (Unsupported, lack features found in the bash versions)
+  if [[ -z ${GIT_PROMPT_STATUS_COMMAND} ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
+
   # template for displaying the current virtual environment
   # use the placeholder _VIRTUALENV_ will be replaced with
   # the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)


### PR DESCRIPTION
The new variables introduced are checked for in define_undefined_git_prompt_colors, and Two themes remain that override that function.