### PR TITLE
Use `test -v` to allow overriding defaults with empty strings

### DIFF
--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -34,22 +34,22 @@ define_helpers() {
 }
 
 define_undefined_git_prompt_colors() {
-  if [[ -z ${GIT_PROMPT_THEME_NAME} ]]; then GIT_PROMPT_THEME_NAME="Default"; fi
+  if [[ ! -v GIT_PROMPT_THEME_NAME ]]; then GIT_PROMPT_THEME_NAME="Default"; fi
 
   # These are the color definitions used by gitprompt.sh
-  if [[ -z ${GIT_PROMPT_PREFIX} ]]; then GIT_PROMPT_PREFIX="["; fi                 # start of the git info string
-  if [[ -z ${GIT_PROMPT_SUFFIX} ]]; then GIT_PROMPT_SUFFIX="]"; fi                 # the end of the git info string
-  if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR="|"; fi              # separates each item
+  if [[ ! -v GIT_PROMPT_PREFIX ]]; then GIT_PROMPT_PREFIX="["; fi                 # start of the git info string
+  if [[ ! -v GIT_PROMPT_SUFFIX ]]; then GIT_PROMPT_SUFFIX="]"; fi                 # the end of the git info string
+  if [[ ! -v GIT_PROMPT_SEPARATOR ]]; then GIT_PROMPT_SEPARATOR="|"; fi              # separates each item
 
-  if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
-  if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
-  if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
+  if [[ ! -v GIT_PROMPT_BRANCH ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
+  if [[ ! -v GIT_PROMPT_STAGED ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [[ ! -v GIT_PROMPT_CONFLICTS ]]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
+  if [[ ! -v GIT_PROMPT_CHANGED ]]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
 
-  if [[ -z ${GIT_PROMPT_REMOTE} ]]; then GIT_PROMPT_REMOTE=" "; fi                 # the remote branch name (if any) and the symbols for ahead and behind
-  if [[ -z ${GIT_PROMPT_UNTRACKED} ]]; then GIT_PROMPT_UNTRACKED="${Cyan}…"; fi       # the number of untracked files/dirs
-  if [[ -z ${GIT_PROMPT_STASHED} ]]; then GIT_PROMPT_STASHED="${BoldBlue}⚑ "; fi    # the number of stashed files/dir
-  if [[ -z ${GIT_PROMPT_CLEAN} ]]; then GIT_PROMPT_CLEAN="${BoldGreen}✔"; fi      # a colored flag indicating a "clean" repo
+  if [[ ! -v GIT_PROMPT_REMOTE ]]; then GIT_PROMPT_REMOTE=" "; fi                 # the remote branch name (if any) and the symbols for ahead and behind
+  if [[ ! -v GIT_PROMPT_UNTRACKED ]]; then GIT_PROMPT_UNTRACKED="${Cyan}…"; fi       # the number of untracked files/dirs
+  if [[ ! -v GIT_PROMPT_STASHED ]]; then GIT_PROMPT_STASHED="${BoldBlue}⚑ "; fi    # the number of stashed files/dir
+  if [[ ! -v GIT_PROMPT_CLEAN ]]; then GIT_PROMPT_CLEAN="${BoldGreen}✔"; fi      # a colored flag indicating a "clean" repo
 
   # For the command indicator, the placeholder _LAST_COMMAND_STATE_
   # will be replaced with the exit code of the last command
@@ -57,37 +57,37 @@ define_undefined_git_prompt_colors() {
   # GIT_PROMPT_COMMAND_OK="${Green}✔-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of 0
   # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of other than 0
 
-  if [[ -z ${GIT_PROMPT_COMMAND_OK} ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔"; fi    # indicator if the last command returned with an exit code of 0
-  if [[ -z ${GIT_PROMPT_COMMAND_FAIL} ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_"; fi    # indicator if the last command returned with an exit code of other than 0
+  if [[ ! -v GIT_PROMPT_COMMAND_OK ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔"; fi    # indicator if the last command returned with an exit code of 0
+  if [[ ! -v GIT_PROMPT_COMMAND_FAIL ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_"; fi    # indicator if the last command returned with an exit code of other than 0
 
   # Possible to change which command is used to create git status information
   # There are three options:
   # 1) gitstatus.sh (uses git status --branch --porcelain - fast, requires git > 1.7.10)
   # 2) gitstatus_pre-1.7.10.sh (Uses a variety of git commands and pipes - slower, works with older git clients)
   # 3) gitstatus.py (Unsupported, lack features found in the bash versions)
-  if [[ -z ${GIT_PROMPT_STATUS_COMMAND} ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
+  if [[ ! -v GIT_PROMPT_STATUS_COMMAND ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
 
   # template for displaying the current virtual environment
   # use the placeholder _VIRTUALENV_ will be replaced with
   # the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)
-  if [[ -z ${GIT_PROMPT_VIRTUALENV} ]]; then GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "; fi
+  if [[ ! -v GIT_PROMPT_VIRTUALENV ]]; then GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "; fi
 
   # template for displaying the current remote tracking branch
   # use the placeholder _UPSTREAM_ will be replaced with
   # the name of the current remote tracking branch
-  if [[ -z ${GIT_PROMPT_UPSTREAM} ]]; then GIT_PROMPT_UPSTREAM=" {${Blue}_UPSTREAM_${ResetColor}}"; fi
+  if [[ ! -v GIT_PROMPT_UPSTREAM ]]; then GIT_PROMPT_UPSTREAM=" {${Blue}_UPSTREAM_${ResetColor}}"; fi
 
   # _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
-  if [[ -z ${GIT_PROMPT_START_USER} ]]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"; fi
-  if [[ -z ${GIT_PROMPT_START_ROOT} ]]; then GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"; fi
-  if [[ -z ${GIT_PROMPT_END_USER} ]]; then GIT_PROMPT_END_USER=" \n${White}${Time12a}${ResetColor} $ "; fi
-  if [[ -z ${GIT_PROMPT_END_ROOT} ]]; then GIT_PROMPT_END_ROOT=" \n${White}${Time12a}${ResetColor} # "; fi
+  if [[ ! -v GIT_PROMPT_START_USER ]]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"; fi
+  if [[ ! -v GIT_PROMPT_START_ROOT ]]; then GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"; fi
+  if [[ ! -v GIT_PROMPT_END_USER ]]; then GIT_PROMPT_END_USER=" \n${White}${Time12a}${ResetColor} $ "; fi
+  if [[ ! -v GIT_PROMPT_END_ROOT ]]; then GIT_PROMPT_END_ROOT=" \n${White}${Time12a}${ResetColor} # "; fi
 
   # Please do not add colors to these symbols
-  if [[ -z ${GIT_PROMPT_SYMBOLS_AHEAD} ]]; then GIT_PROMPT_SYMBOLS_AHEAD="↑·"; fi             # The symbol for "n versions ahead of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_BEHIND} ]]; then GIT_PROMPT_SYMBOLS_BEHIND="↓·"; fi            # The symbol for "n versions behind of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_PREHASH} ]]; then GIT_PROMPT_SYMBOLS_PREHASH=":"; fi            # Written before hash of commit, if no name could be found
-  if [[ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING} ]]; then GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"; fi # This symbol is written after the branch, if the branch is not tracked
+  if [[ ! -v GIT_PROMPT_SYMBOLS_AHEAD ]]; then GIT_PROMPT_SYMBOLS_AHEAD="↑·"; fi             # The symbol for "n versions ahead of origin"
+  if [[ ! -v GIT_PROMPT_SYMBOLS_BEHIND ]]; then GIT_PROMPT_SYMBOLS_BEHIND="↓·"; fi            # The symbol for "n versions behind of origin"
+  if [[ ! -v GIT_PROMPT_SYMBOLS_PREHASH ]]; then GIT_PROMPT_SYMBOLS_PREHASH=":"; fi            # Written before hash of commit, if no name could be found
+  if [[ ! -v GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING ]]; then GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"; fi # This symbol is written after the branch, if the branch is not tracked
 }
 
 # call only from theme file


### PR DESCRIPTION
I had a problem that I could not set `GIT_PROMPT_COMMAND_OK=''`. Fixed the problem with this.
