### PR TITLE
Changed the themes to properly override Default theme

### DIFF
--- a/themes/Single_line_NoExitState.bgptheme
+++ b/themes/Single_line_NoExitState.bgptheme
@@ -1,11 +1,12 @@
 # This is an alternative approach. Single line in git repo.
 override_git_prompt_colors() {
-  GIT_PROMPT_THEME_NAME="Single_line"
+  GIT_PROMPT_THEME_NAME="Single_line_NoExitState"
 
+  GIT_PROMPT_COMMAND_FAIL="${Red}✘"
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${BoldYellow}${PathShort}${ResetColor}"
   GIT_PROMPT_END_USER="${ResetColor} $ "
   GIT_PROMPT_END_ROOT="${BoldRed} # "
 }
 
-reload_git_prompt_colors "Single_line"
+reload_git_prompt_colors "Single_line_NoExitState"
 

--- a/themes/Single_line_Solarized.bgptheme
+++ b/themes/Single_line_Solarized.bgptheme
@@ -15,7 +15,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_PREFIX="[ "
   GIT_PROMPT_SUFFIX=" ]"
   GIT_PROMPT_SEPARATOR=" |"
-  GIT_PROMPT_STAGED=" ${Yellow}●${ResetColor}"
+  GIT_PROMPT_STAGED=" ${Yellow}● ${ResetColor}"
   GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"
   GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"

--- a/themes/Single_line_Solarized.bgptheme
+++ b/themes/Single_line_Solarized.bgptheme
@@ -4,111 +4,31 @@
 # without the indicator of the last command state 
 # tweaked for Ubuntu terminal fonts
 
-unset_git_prompt_colors() {
-  unset Time12a
-  unset PathShort
-  unset GIT_PROMPT_PREFIX
-  unset GIT_PROMPT_SUFFIX
-  unset GIT_PROMPT_SEPARATOR
-  unset GIT_PROMPT_BRANCH
-  unset GIT_PROMPT_STAGED
-  unset GIT_PROMPT_CONFLICTS
-  unset GIT_PROMPT_CHANGED
-  unset GIT_PROMPT_REMOTE
-  unset GIT_PROMPT_UNTRACKED
-  unset GIT_PROMPT_STASHED
-  unset GIT_PROMPT_CLEAN
-  unset GIT_PROMPT_COMMAND_OK
-  unset GIT_PROMPT_COMMAND_FAIL
-  unset GIT_PROMPT_VIRTUALENV
-  unset GIT_PROMPT_UPSTREAM
-  unset GIT_PROMPT_START_USER
-  unset GIT_PROMPT_START_ROOT
-  unset GIT_PROMPT_END_USER
-  unset GIT_PROMPT_END_ROOT
-  unset GIT_PROMPT_SYMBOLS_AHEAD
-  unset GIT_PROMPT_SYMBOLS_BEHIND
-  unset GIT_PROMPT_SYMBOLS_PREHASH
-  unset GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING
-}
-
 define_helpers() {
   PathShort="${BoldBlue}\u:${Cyan}\W"
 }
 
-define_undefined_git_prompt_colors() {
-  if [[ -z ${GIT_PROMPT_THEME_NAME} ]]; then GIT_PROMPT_THEME_NAME="Single_line_Solarized"; fi
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Single_line_Solarized"
 
-  # These are the color definitions used by gitprompt.sh
-  if [[ -z ${GIT_PROMPT_PREFIX} ]]; then GIT_PROMPT_PREFIX="[ "; fi                 # start of the git info string
-  if [[ -z ${GIT_PROMPT_SUFFIX} ]]; then GIT_PROMPT_SUFFIX=" ]"; fi                 # the end of the git info string
-  if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR=" |"; fi           # separates each item
 
-  if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi                   # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Yellow}●${ResetColor}"; fi        # the number of staged files/directories
-  if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"; fi # the number of files in conflict
-  if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"; fi    # the number of changed files
+  GIT_PROMPT_PREFIX="[ "
+  GIT_PROMPT_SUFFIX=" ]"
+  GIT_PROMPT_SEPARATOR=" |"
+  GIT_PROMPT_STAGED=" ${Yellow}●${ResetColor}"
+  GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"
+  GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"
+  GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
+  GIT_PROMPT_STASHED=" ${BoldMagenta}⚑ ${ResetColor}"
+  GIT_PROMPT_CLEAN=" ${Green}✔ ${ResetColor}"
 
-  if [[ -z ${GIT_PROMPT_REMOTE} ]]; then GIT_PROMPT_REMOTE=" "; fi                              # the remote branch name (if any) and the symbols for ahead and behind
-  if [[ -z ${GIT_PROMPT_UNTRACKED} ]]; then GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"; fi   # the number of untracked files/dirs
-  if [[ -z ${GIT_PROMPT_STASHED} ]]; then GIT_PROMPT_STASHED=" ${BoldMagenta}⚑ ${ResetColor}"; fi  # the number of stashed files/dir
-  if [[ -z ${GIT_PROMPT_CLEAN} ]]; then GIT_PROMPT_CLEAN=" ${Green}✔ ${ResetColor}"; fi     # a colored flag indicating a "clean" repo
+  GIT_PROMPT_COMMAND_FAIL="${Red}✘"
 
-  # For the command indicator, the placeholder _LAST_COMMAND_STATE_
-  # will be replaced with the exit code of the last command
-  # e.g.
-  # GIT_PROMPT_COMMAND_OK="${Green}✔-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of 0
-  # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of other than 0
+  GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"
+  GIT_PROMPT_END_USER="${BoldBlue} ➭ ${ResetColor}"
+  GIT_PROMPT_END_ROOT="${BoldRed} # "
 
-  if [[ -z ${GIT_PROMPT_COMMAND_OK} ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔"; fi    # indicator if the last command returned with an exit code of 0
-  if [[ -z ${GIT_PROMPT_COMMAND_FAIL} ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘"; fi  # indicator if the last command returned with an exit code of other than 0
-
-  # Possible to change which command is used to create git status information
-  # There are three options:
-  # 1) gitstatus.sh (uses git status --branch --porcelain - fast, requires git > 1.7.10)
-  # 2) gitstatus_pre-1.7.10.sh (Uses a variety of git commands and pipes - slower, works with older git clients)
-  # 3) gitstatus.py (Unsupported, lack features found in the bash versions)
-  if [[ -z ${GIT_PROMPT_STATUS_COMMAND} ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
-
-  # template for displaying the current virtual environment
-  # use the placeholder _VIRTUALENV_ will be replaced with
-  # the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)
-  if [[ -z ${GIT_PROMPT_VIRTUALENV} ]]; then GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "; fi
-
-  # template for displaying the current remote tracking branch
-  # use the placeholder _UPSTREAM_ will be replaced with
-  # the name of the current remote tracking branch
-  if [[ -z ${GIT_PROMPT_UPSTREAM} ]]; then GIT_PROMPT_UPSTREAM=" {${Blue}_UPSTREAM_${ResetColor}}"; fi
-
-  # _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
-  if [[ -z ${GIT_PROMPT_START_USER} ]]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"; fi
-
-  if [[ -z ${GIT_PROMPT_START_ROOT} ]]; then GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"; fi
-  if [[ -z ${GIT_PROMPT_END_USER} ]]; then GIT_PROMPT_END_USER="${BoldBlue} ➭ ${ResetColor}"; fi  # Reset color for user
-  if [[ -z ${GIT_PROMPT_END_ROOT} ]]; then GIT_PROMPT_END_ROOT="${BoldRed} # "; fi     # Bright red for Root
-
-  # Please do not add colors to these symbols
-  if [[ -z ${GIT_PROMPT_SYMBOLS_AHEAD} ]]; then GIT_PROMPT_SYMBOLS_AHEAD="↑·"; fi     # The symbol for "n versions ahead of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_BEHIND} ]]; then GIT_PROMPT_SYMBOLS_BEHIND="↓·"; fi   # The symbol for "n versions behind of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_PREHASH} ]]; then GIT_PROMPT_SYMBOLS_PREHASH=":"; fi  # Written before hash of commit, if no name could be found
-  if [[ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING} ]]; then GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="✭"; fi # This symbol is written after the branch, if the branch is not tracked
-}
-
-# call only from theme file
-reload_git_prompt_colors() {
-  if [[ "${GIT_PROMPT_THEME_NAME}" != $1 ]]; then
-    unset_git_prompt_colors
-    define_helpers
-    override_git_prompt_colors
-    define_undefined_git_prompt_colors
-  fi
-}
-
-if [[ "${GIT_PROMPT_THEME}" == "Single_line_Solarized" && "${GIT_PROMPT_THEME_NAME}" != "Single_line_Solarized" ]]; then
-  define_helpers
-  define_undefined_git_prompt_colors
-fi
-
-overide_git_prompt_colors() {
   GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="✭"
 }
+
+reload_git_prompt_colors "Single_line_Solarized"

--- a/themes/Single_line_Ubuntu.bgptheme
+++ b/themes/Single_line_Ubuntu.bgptheme
@@ -1,106 +1,25 @@
 # This is an alternative approach. Single line in git repo.
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Single_line_Ubuntu"
 
-unset_git_prompt_colors() {
-  unset Time12a
-  unset PathShort
-  unset GIT_PROMPT_PREFIX
-  unset GIT_PROMPT_SUFFIX
-  unset GIT_PROMPT_SEPARATOR
-  unset GIT_PROMPT_BRANCH
-  unset GIT_PROMPT_STAGED
-  unset GIT_PROMPT_CONFLICTS
-  unset GIT_PROMPT_CHANGED
-  unset GIT_PROMPT_REMOTE
-  unset GIT_PROMPT_UNTRACKED
-  unset GIT_PROMPT_STASHED
-  unset GIT_PROMPT_CLEAN
-  unset GIT_PROMPT_COMMAND_OK
-  unset GIT_PROMPT_COMMAND_FAIL
-  unset GIT_PROMPT_VIRTUALENV
-  unset GIT_PROMPT_UPSTREAM
-  unset GIT_PROMPT_START_USER
-  unset GIT_PROMPT_START_ROOT
-  unset GIT_PROMPT_END_USER
-  unset GIT_PROMPT_END_ROOT
-  unset GIT_PROMPT_SYMBOLS_AHEAD
-  unset GIT_PROMPT_SYMBOLS_BEHIND
-  unset GIT_PROMPT_SYMBOLS_PREHASH
-  unset GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING
+  GIT_PROMPT_PREFIX="[ "
+  GIT_PROMPT_SUFFIX=" ]"
+  GIT_PROMPT_SEPARATOR=" |"
+  GIT_PROMPT_STAGED=" ${Red}● ${ResetColor}"
+  GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"
+  GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"
+  GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
+  GIT_PROMPT_STASHED=" ${BoldBlue}⚑ ${ResetColor}"
+  GIT_PROMPT_CLEAN=" ${BoldGreen}✔ ${ResetColor}"
+
+  GIT_PROMPT_COMMAND_OK="${Green}✔ "
+  GIT_PROMPT_COMMAND_FAIL="${Red}✘ "
+
+  GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${Cyan}${PathShort}${ResetColor}"
+  GIT_PROMPT_END_USER="${ResetColor} $ "
+  GIT_PROMPT_END_ROOT="${BoldRed} # "
+
 }
 
-define_helpers() {
-  Time12a="\$(date +%H:%M)"
-  PathShort="\w";
-}
+reload_git_prompt_colors "Single_line_Ubuntu"
 
-define_undefined_git_prompt_colors() {
-  if [[ -z ${GIT_PROMPT_THEME_NAME} ]]; then GIT_PROMPT_THEME_NAME="Single_line_Ubuntu"; fi
-
-  # These are the color definitions used by gitprompt.sh
-  if [[ -z ${GIT_PROMPT_PREFIX} ]]; then GIT_PROMPT_PREFIX="[ "; fi                 # start of the git info string
-  if [[ -z ${GIT_PROMPT_SUFFIX} ]]; then GIT_PROMPT_SUFFIX=" ]"; fi                 # the end of the git info string
-  if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR=" |"; fi           # separates each item
-
-  if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi                   # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED=" ${Red}● ${ResetColor}"; fi        # the number of staged files/directories
-  if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS=" ${Red}✖ ${ResetColor}"; fi # the number of files in conflict
-  if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED=" ${Blue}✚ ${ResetColor}"; fi    # the number of changed files
-
-  if [[ -z ${GIT_PROMPT_REMOTE} ]]; then GIT_PROMPT_REMOTE=" "; fi                              # the remote branch name (if any) and the symbols for ahead and behind
-  if [[ -z ${GIT_PROMPT_UNTRACKED} ]]; then GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"; fi   # the number of untracked files/dirs
-  if [[ -z ${GIT_PROMPT_STASHED} ]]; then GIT_PROMPT_STASHED=" ${BoldBlue}⚑ ${ResetColor}"; fi  # the number of stashed files/dir
-  if [[ -z ${GIT_PROMPT_CLEAN} ]]; then GIT_PROMPT_CLEAN=" ${BoldGreen}✔ ${ResetColor}"; fi     # a colored flag indicating a "clean" repo
-
-  # For the command indicator, the placeholder _LAST_COMMAND_STATE_
-  # will be replaced with the exit code of the last command
-  # e.g.
-  # GIT_PROMPT_COMMAND_OK="${Green}✔-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of 0
-  # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of other than 0
-
-  if [[ -z ${GIT_PROMPT_COMMAND_OK} ]]; then GIT_PROMPT_COMMAND_OK="${Green}✔ "; fi    # indicator if the last command returned with an exit code of 0
-  if [[ -z ${GIT_PROMPT_COMMAND_FAIL} ]]; then GIT_PROMPT_COMMAND_FAIL="${Red}✘ "; fi  # indicator if the last command returned with an exit code of other than 0
-
-  # Possible to change which command is used to create git status information
-  # There are three options:
-  # 1) gitstatus.sh (uses git status --branch --porcelain - fast, requires git > 1.7.10)
-  # 2) gitstatus_pre-1.7.10.sh (Uses a variety of git commands and pipes - slower, works with older git clients)
-  # 3) gitstatus.py (Unsupported, lack features found in the bash versions)
-  if [[ -z ${GIT_PROMPT_STATUS_COMMAND} ]]; then GIT_PROMPT_STATUS_COMMAND="gitstatus.sh"; fi    # Point out the command to get the git status from
-  
-  # template for displaying the current virtual environment
-  # use the placeholder _VIRTUALENV_ will be replaced with
-  # the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)
-  if [[ -z ${GIT_PROMPT_VIRTUALENV} ]]; then GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "; fi
-
-  # template for displaying the current remote tracking branch
-  # use the placeholder _UPSTREAM_ will be replaced with
-  # the name of the current remote tracking branch
-  if [[ -z ${GIT_PROMPT_UPSTREAM} ]]; then GIT_PROMPT_UPSTREAM=" {${Blue}_UPSTREAM_${ResetColor}}"; fi
-  
-  # _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
-  if [[ -z ${GIT_PROMPT_START_USER} ]]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${Cyan}${PathShort}${ResetColor}"; fi
-  if [[ -z ${GIT_PROMPT_START_ROOT} ]]; then GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"; fi
-  if [[ -z ${GIT_PROMPT_END_USER} ]]; then GIT_PROMPT_END_USER="${ResetColor} $ "; fi  # Reset color for user
-  if [[ -z ${GIT_PROMPT_END_ROOT} ]]; then GIT_PROMPT_END_ROOT="${BoldRed} # "; fi     # Bright red for Root
-
-  # Please do not add colors to these symbols
-  if [[ -z ${GIT_PROMPT_SYMBOLS_AHEAD} ]]; then GIT_PROMPT_SYMBOLS_AHEAD="↑·"; fi     # The symbol for "n versions ahead of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_BEHIND} ]]; then GIT_PROMPT_SYMBOLS_BEHIND="↓·"; fi   # The symbol for "n versions behind of origin"
-  if [[ -z ${GIT_PROMPT_SYMBOLS_PREHASH} ]]; then GIT_PROMPT_SYMBOLS_PREHASH=":"; fi  # Written before hash of commit, if no name could be found
-  if [[ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING} ]]; then GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"; fi # This symbol is written after the branch, if the branch is not tracked
-}
-
-# call only from theme file
-reload_git_prompt_colors() {
-  if [[ "${GIT_PROMPT_THEME_NAME}" != $1 ]]; then
-    unset_git_prompt_colors
-    define_helpers
-    override_git_prompt_colors
-    define_undefined_git_prompt_colors
-  fi
-}
-
-if [[ "${GIT_PROMPT_THEME}" == "Single_line_Ubuntu" && "${GIT_PROMPT_THEME_NAME}" != "Single_line_Ubuntu" ]]; then
-  define_helpers
-  define_undefined_git_prompt_colors
-fi


### PR DESCRIPTION
A few themes were a copy of the default theme instead of overriding the variables needed setting.

To avoid the `test -z` problem for all of them, I refactored them to override Default instead.

I did a diff using

```sh
set |egrep "^GIT_PROMPT_*"
```

To make sure that all variables are set equally between the old and new version.