### PR TITLE
Make counting ALL untracked files optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ git clone https://github.com/magicmonty/bash-git-prompt.git .bash-git-prompt
    # GIT_PROMPT_FETCH_REMOTE_STATUS=0   # uncomment to avoid fetching remote status
 
    # GIT_PROMPT_SHOW_UPSTREAM=1 # uncomment to show upstream tracking branch
-
+   # GIT_SHOW_UNTRACKED_FILES=all # can be no, normal or all; determines counting of untracked files
+   
    # GIT_PROMPT_STATUS_COMMAND=gitstatus_pre-1.7.10.sh # uncomment to support Git older than 1.7.10
 
    # GIT_PROMPT_START=...    # uncomment for custom prompt start sequence
@@ -135,6 +136,10 @@ git clone https://github.com/magicmonty/bash-git-prompt.git .bash-git-prompt
    # GIT_PROMPT_THEME=Solarized # use theme optimized for solarized color scheme
    source ~/.bash-git-prompt/gitprompt.sh
 ```
+
+You can set the `GIT_SHOW_UNTRACKED_FILES` variable to `no` or `normal` to speed things up if you have lots of
+untracked files in your repository. This can be the case for build systems that put their build artifacts in
+the subdirectory structure of the git repository.
 
 - `cd` to a git repository and test it!
 

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 # gitstatus.sh -- produce the current git repo status on STDOUT
 # Functionally equivalent to 'gitstatus.py', but written in bash (not python).
 #
@@ -15,7 +15,11 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-gitstatus=$( LC_ALL=C git status --untracked-files=all --porcelain --branch )
+if [ -z "${GIT_SHOW_UNTRACKED_FILES}" ]; then
+    GIT_SHOW_UNTRACKED_FILES="all"
+fi
+
+gitstatus=$( LC_ALL=C git status --untracked-files=${GIT_SHOW_UNTRACKED_FILES} --porcelain --branch )
 
 # if the status is fatal, exit now
 [[ "$?" -ne 0 ]] && exit 0


### PR DESCRIPTION
I am working via sshfs on a large repository which mixes source files with build artifacts. Hence I get potentially lots and lots of untracked files. Sometimes the git status takes 5 minutes to complete, if the connection is bad. I also do not need this information. 

So I made the parameter for git status --untracked-files configurable. There is now a new environment variable, called GIT_SHOW_UNTRACKED_FILES, which if set is passed to git status. If it is not set, default behaviour of "all" will apply. Setting it to "no" or "normal" will speed things up a lot.