### PR TITLE
Take conflicts into account for 'clean' flag

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -46,7 +46,7 @@ if [[ "$__GIT_PROMPT_IGNORE_STASH" != "1" ]]; then
 fi
 
 clean=0
-if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed == 0 )) ; then
+if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed == 0 && num_conflicts )) ; then
   clean=1
 fi
 

--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -50,7 +50,7 @@ if [[ "$__GIT_PROMPT_IGNORE_STASH" != "1" ]]; then
 fi
 
 clean=0
-if (( num_changed == 0 && num_staged == 0 && num_U == 0 && num_untracked == 0 && num_stashed == 0 )) ; then
+if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed == 0 && num_conflicts == 0 )) ; then
   clean=1
 fi
 


### PR DESCRIPTION
The conflicts flag is not taken into account for the *computation* of the `clean` flag when using `gitstatus.sh` and `gitstatus_pre-1.7.10.sh`. However it is in the python version `gitstatus.py`.

In case your git working tree has nothing that make it *dirty* but conflicts, the prompt shows a wrong `clean` flag alongside the correct `conflict`:
![image](https://cloud.githubusercontent.com/assets/476650/13034972/aa5e6868-d343-11e5-937e-cc8e35935b5d.png)

While reporting this fix into the `gitstatus_pre-1.7.10.sh` as well, I noticed that the `num_U` variable was not set nowhere. So I deleted it.