### PR TITLE
Show an unannotated tag too

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -60,7 +60,7 @@ if [[ "$branch" == *"Initial commit on"* ]]; then
   branch="${fields[3]}"
   remote="_NO_REMOTE_TRACKING_"
 elif [[ "$branch" == *"no branch"* ]]; then
-  tag=$( git describe --exact-match )
+  tag=$( git describe --tags --exact-match )
   if [[ -n "$tag" ]]; then
     branch="$tag"
   else


### PR DESCRIPTION
When working tree is at a detached head and that commit id has a tag, currently we only show it when the tag is annotated, even if an unannotated tag is available.  Adding the --tags flag to git-describe will let it fall back to choosing an unannotated tag if there is no annotated tag.  If neither kind of tag exists for this commit id, a short SHA1 hash is still returned.  Since a lot of git repos use unannotated tags (including this one), this change should make the bash-git-prompt a little more friendly for users who are looking at a historical point in time.

This has been tested with git 1.9.1 and 2.5.0 with equivalent results.

Attached is a short shell script demonstrating the behavior on a toy git repo:
[example.sh.txt](https://github.com/magicmonty/bash-git-prompt/files/190269/example.sh.txt)

Example output is below:

```
$ /tmp/example.sh 
Show git version, for the record.
git version 1.9.1
Creating toy git repo.
Making a few commits and tagging them.
Checking out unannotated tag 'unannotated-tag-1'.
By default, we cannot find this commit's tag unless it is annotated.
fatal: no tag exactly matches '3db05dadc65ea36714059946a7ab7c957bfdc039'
With the --tags flag, we can also find an annotated flag.
unannotated-tag-1
Adding a more unannotated tags to the same commit id.  The tag that sorts first (using locale-specific sort order) is shown.
aaa-alphabetically-first-unannotated-tag
Adding an annotated tag.  Even with the --tags flag, git-describe prefers to return an annotated tag rather than any unannotated tag.
nnn-alphabetically-middle-annotated-tag
```
