### PR TITLE
Make pr#238 work for legacy git as well

### DIFF
--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -58,7 +58,7 @@ remote=
 upstream=
 
 if [[ -z "$branch" ]]; then
-  tag=$( git describe --exact-match 2>/dev/null )
+  tag=$( git describe --branch --exact-match 2>/dev/null )
   if [[ -n "$tag" ]]; then
     branch="$tag"
   else


### PR DESCRIPTION
If pr #238 is merged, this should make legacy Git work the same way. I ran the provided script from #238 as well:

```
Show git version, for the record.
git version 1.7.9.5
Creating toy git repo.
Making a few commits and tagging them.
Checking out unannotated tag 'unannotated-tag-1'.
By default, we cannot find this commit's tag unless it is annotated.
fatal: no tag exactly matches '7dfb6ae84369269e36618b2011c71579fec7c0a1'
With the --tags flag, we can also find an annotated flag.
unannotated-tag-1
Adding a more unannotated tags to the same commit id.  The tag that sorts first (using locale-specific sort order) is shown.
aaa-alphabetically-first-unannotated-tag
Adding an annotated tag.  Even with the --tags flag, git-describe prefers to return an annotated tag rather than any unannotated tag.
nnn-alphabetically-middle-annotated-tag
```