### PR TITLE
fix deleted item count and fix last_command_indicator coloring

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -518,7 +518,7 @@ function updatePrompt() {
     NEW_PROMPT="$EMPTY_PROMPT"
   fi
 
-  PS1="${NEW_PROMPT//_LAST_COMMAND_INDICATOR_/${LAST_COMMAND_INDICATOR}}"
+  PS1="${NEW_PROMPT//_LAST_COMMAND_INDICATOR_/${LAST_COMMAND_INDICATOR}${ResetColor}}"
 }
 
 # Helper function that returns virtual env information to be set in prompt

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -29,6 +29,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   case "$status" in
     \#\#) branch_line="${line/\.\.\./^}" ;;
     ?M) ((num_changed++)) ;;
+    ?D) ((num_changed++)) ;;
     U?) ((num_conflicts++)) ;;
     \?\?) ((num_untracked++)) ;;
     *) ((num_staged++)) ;;


### PR DESCRIPTION
(1) Deleted items were incorrectly counted as staged
(2) A ResetColor string after the last_command_indicator makes the command line colors be a bit more predictable.