### PR TITLE
ecape gp_set_window_title output

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -554,7 +554,7 @@ function gp_truncate_pwd {
 
 # Sets the window title to the given argument string
 function gp_set_window_title {
-  echo -ne "\033]0;"$@"\007"
+  echo -ne "\[\033]0;"$@"\007\]"
 }
 
 function prompt_callback_default {


### PR DESCRIPTION
Escape (\[...\]) output of gp_set_window_title so that (the terminal/readline, I guess) calculate the prompt width correctly and editing multi-line commands doesn't mess up the screen.