### PR TITLE
Fix repeated 'git_prompt_color_samples' bug

### DIFF
--- a/git-prompt-help.sh
+++ b/git-prompt-help.sh
@@ -65,7 +65,7 @@ git_prompt_color_samples() {
     echo -e "${color}$1${ResetColor}" | sed 's/\\\]//g'  | sed 's/\\\[//g'
   }
 
-  local x
+  local x=0
   while (( x < 8 )) ; do
     showColor ${ColorNames[x]}
     showColor "Dim${ColorNames[x]}"

--- a/git-prompt-help.sh
+++ b/git-prompt-help.sh
@@ -65,6 +65,7 @@ git_prompt_color_samples() {
     echo -e "${color}$1${ResetColor}" | sed 's/\\\]//g'  | sed 's/\\\[//g'
   }
 
+  local x
   while (( x < 8 )) ; do
     showColor ${ColorNames[x]}
     showColor "Dim${ColorNames[x]}"


### PR DESCRIPTION
Made 'x' a local variable so the 'git_prompt_color_samples' command can be repeated.

See issue #250.