### PR TITLE
Fix bug in gitstatus.sh. If a file is modified in the index and at the same time in the work tree

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -28,6 +28,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
   case "$status" in
     \#\#) branch_line="${line/\.\.\./^}" ;;
+    MM) ((num_staged++)); ((num_changed++)) ;;
     ?M) ((num_changed++)) ;;
     ?D) ((num_changed++)) ;;
     U?) ((num_conflicts++)) ;;


### PR DESCRIPTION
**_Starting point:**_

✔  22:54 ~/workspace/aws-cli [ develop {origin/develop} | ✚ 1 ] $ git status
On branch develop
Your branch is up-to-date with 'origin/develop'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

```
   modified:   tox.ini
```

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

```
   modified:   tox.ini
```

**_Current output:**_

✔  22:54 ~/workspace/aws-cli [ develop {origin/develop} | ✚ 1 ] $ git status

**_Expected output:**_

✔  22:54 ~/workspace/aws-cli [ develop {origin/develop} | ● 1 ✚ 1 ] $ git status
