### PR TITLE
Fix index lock issue

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -437,6 +437,20 @@ function replaceSymbols() {
   echo ${VALUE2//_PREHASH_/${GIT_PROMPT_SYMBOLS_PREHASH}}
 }
 
+function createPrivateIndex {
+  # Create a copy of the index to avoid conflicts with parallel git commands, e.g. git rebase.
+  local __GIT_INDEX_FILE
+  local __GIT_INDEX_PRIVATE
+  if [[ -z "$GIT_INDEX_FILE" ]]; then
+    __GIT_INDEX_FILE="$(git rev-parse --git-dir)/index"
+  else
+    __GIT_INDEX_FILE="$GIT_INDEX_FILE"
+  fi
+  __GIT_INDEX_PRIVATE="/tmp/git-index-private$$"
+  cp "$__GIT_INDEX_FILE" "$__GIT_INDEX_PRIVATE" 2>/dev/null
+  echo "$__GIT_INDEX_PRIVATE"
+}
+
 function updatePrompt() {
   local LAST_COMMAND_INDICATOR
   local PROMPT_LEADING_SPACE
@@ -455,6 +469,11 @@ function updatePrompt() {
   else
     export __GIT_PROMPT_SHOW_UNTRACKED_FILES=${GIT_PROMPT_SHOW_UNTRACKED_FILES}
   fi
+
+  local GIT_INDEX_PRIVATE="$(createPrivateIndex)"
+  #important to define GIT_INDEX_FILE as local: This way it only affects this function (and below) - even with the export afterwards
+  local GIT_INDEX_FILE
+  export GIT_INDEX_FILE="$GIT_INDEX_PRIVATE"
 
   local -a git_status_fields
   git_status_fields=($("$__GIT_STATUS_CMD" 2>/dev/null))
@@ -528,6 +547,7 @@ function updatePrompt() {
   fi
 
   PS1="${NEW_PROMPT//_LAST_COMMAND_INDICATOR_/${LAST_COMMAND_INDICATOR}${ResetColor}}"
+  rm "$GIT_INDEX_PRIVATE" 2>/dev/null
 }
 
 # Helper function that returns virtual env information to be set in prompt


### PR DESCRIPTION
If git commands run simultaneously on the same repository, one of it might fail because of an locked index. This is e.g. extremly annoying during a long lasting rebase. (In one terminal you run the rebase. Just switching to the same git working directory in another terminal might be enough to make the rebase fail - because "bash-git-promt" fetches the information from "git status" which in turn tries to lock the index file for a short moment)

This pull request circumvents this by introducing a private index file. This is done by using a copy of the real index file. While this bears the risk (also quite unlikely) of a broken index copy, it will only affect "bash-git-prompt" and not the real stuff.

One example of this problem is documented here: https://www.quora.com/Why-do-my-git-operations-often-fail-with-a-lock-error