### PR TITLE
Fix count for files being staged, unstaged at the same time

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -28,10 +28,11 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
   case "$status" in
     \#\#) branch_line="${line/\.\.\./^}" ;;
-    ?M) ((num_changed++)) ;;
-    ?D) ((num_changed++)) ;;
-    U?) ((num_conflicts++)) ;;
+    ?M) ((num_changed++)) ;;&
+    ?D) ((num_changed++)) ;;&
+    U?) ((num_conflicts++)) ;;&
     \?\?) ((num_untracked++)) ;;
+    \ ?) ;;
     *) ((num_staged++)) ;;
   esac
 done <<< "$gitstatus"


### PR DESCRIPTION
A file can be staged AND unstaged at the same time, eg, MM.

Fix is only for git >= 1.7.10