### PR TITLE
Fix count for files being staged, unstaged at the same time, second version

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -26,17 +26,26 @@ num_conflicts=0
 num_untracked=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
-  while true
+  while [[ -n $status ]]
   do
     case "$status" in
+#two fixed character matches, loop finished
       \#\#) branch_line="${line/\.\.\./^}"; break ;;
-      ?M) ((num_changed++)); status=${status:0:1}"_" ;;
-      ?D) ((num_changed++)); status=${status:0:1}"_" ;;
-      U?) ((num_conflicts++)); break ;;
       \?\?) ((num_untracked++)); break ;;
-      \ ?) break ;;
-      *) ((num_staged++)); break ;;
+      U?) ((num_conflicts++)); break;;
+      ?U) ((num_conflicts++)); break;;
+      DD) ((num_conflicts++)); break;;
+      AA) ((num_conflicts++)); break;;
+#two character matches, first loop
+      ?M) ((num_changed++)) ;;
+      ?D) ((num_changed++)) ;;
+      ?\ ) ;;
+#single character matches, second loop
+      U) ((num_conflicts++)) ;;
+      \ ) ;;
+      *) ((num_staged++)) ;;
     esac
+    status=${status:0:-1}
   done
 done <<< "$gitstatus"
 

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -26,15 +26,18 @@ num_conflicts=0
 num_untracked=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
-  case "$status" in
-    \#\#) branch_line="${line/\.\.\./^}" ;;
-    ?M) ((num_changed++)) ;;&
-    ?D) ((num_changed++)) ;;&
-    U?) ((num_conflicts++)) ;;&
-    \?\?) ((num_untracked++)) ;;
-    \ ?) ;;
-    *) ((num_staged++)) ;;
-  esac
+  while true
+  do
+    case "$status" in
+      \#\#) branch_line="${line/\.\.\./^}"; break ;;
+      ?M) ((num_changed++)); status=${status:0:1}"_" ;;
+      ?D) ((num_changed++)); status=${status:0:1}"_" ;;
+      U?) ((num_conflicts++)); break ;;
+      \?\?) ((num_untracked++)); break ;;
+      \ ?) break ;;
+      *) ((num_staged++)); break ;;
+    esac
+  done
 done <<< "$gitstatus"
 
 num_stashed=0


### PR DESCRIPTION
-  operator ;;& replaced to keep bash-3.2 compatibility
- support all status combinations described in manpage of git-status
