### PR TITLE
Make sure aliases for cp and rm are lower priority than the original …

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -447,7 +447,7 @@ function createPrivateIndex {
     __GIT_INDEX_FILE="$GIT_INDEX_FILE"
   fi
   __GIT_INDEX_PRIVATE="/tmp/git-index-private$$"
-  cp "$__GIT_INDEX_FILE" "$__GIT_INDEX_PRIVATE" 2>/dev/null
+  \cp "$__GIT_INDEX_FILE" "$__GIT_INDEX_PRIVATE" 2>/dev/null
   echo "$__GIT_INDEX_PRIVATE"
 }
 
@@ -547,7 +547,7 @@ function updatePrompt() {
   fi
 
   PS1="${NEW_PROMPT//_LAST_COMMAND_INDICATOR_/${LAST_COMMAND_INDICATOR}${ResetColor}}"
-  rm "$GIT_INDEX_PRIVATE" 2>/dev/null
+  \rm -f "$GIT_INDEX_PRIVATE" 2>/dev/null
 }
 
 # Helper function that returns virtual env information to be set in prompt

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -447,7 +447,7 @@ function createPrivateIndex {
     __GIT_INDEX_FILE="$GIT_INDEX_FILE"
   fi
   __GIT_INDEX_PRIVATE="/tmp/git-index-private$$"
-  \cp "$__GIT_INDEX_FILE" "$__GIT_INDEX_PRIVATE" 2>/dev/null
+  command cp "$__GIT_INDEX_FILE" "$__GIT_INDEX_PRIVATE" 2>/dev/null
   echo "$__GIT_INDEX_PRIVATE"
 }
 
@@ -547,7 +547,7 @@ function updatePrompt() {
   fi
 
   PS1="${NEW_PROMPT//_LAST_COMMAND_INDICATOR_/${LAST_COMMAND_INDICATOR}${ResetColor}}"
-  \rm -f "$GIT_INDEX_PRIVATE" 2>/dev/null
+  command rm "$GIT_INDEX_PRIVATE" 2>/dev/null
 }
 
 # Helper function that returns virtual env information to be set in prompt


### PR DESCRIPTION
…command

People that have made aliases for rm and/or cp with the `-i` flag are experiencing that the prompt hangs now.

See http://stackoverflow.com/a/15951879/236365

Thanks to @gcbartlett 

Unsure whether we should have -f on either cp or rm though. It depends on whether the naming of the generated statusfile is unique I guess @DrVanScott 