### PR TITLE
fixes #277, substring expression < 0 issue for older bash versions

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -44,7 +44,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
       \ ) ;;
       *) ((num_staged++)) ;;
     esac
-    status=${status:0:-1}
+    status=${status:0:(${#status}-1)}
   done
 done <<< "$gitstatus"
 


### PR DESCRIPTION
This commit solves the error descibed in #277.

Older versions of bash do not allow negative length values.