### PR TITLE
Possible to not print the number of changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Add to the `~/.bashrc`:
 
    # GIT_PROMPT_SHOW_UPSTREAM=1 # uncomment to show upstream tracking branch
    # GIT_PROMPT_SHOW_UNTRACKED_FILES=all # can be no, normal or all; determines counting of untracked files
+   
+   # GIT_PROMPT_SHOW_CHANGED_FILES_COUNT=0 # uncomment to avoid printing the number of changed files
 
    # GIT_PROMPT_STATUS_COMMAND=gitstatus_pre-1.7.10.sh # uncomment to support Git older than 1.7.10
 

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -470,6 +470,12 @@ function updatePrompt() {
     export __GIT_PROMPT_SHOW_UNTRACKED_FILES=${GIT_PROMPT_SHOW_UNTRACKED_FILES}
   fi
 
+  if [ -z "${GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" ]; then
+    export __GIT_PROMPT_SHOW_CHANGED_FILES_COUNT=1
+  else
+    export __GIT_PROMPT_SHOW_CHANGED_FILES_COUNT=${GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}
+  fi
+
   local GIT_INDEX_PRIVATE="$(createPrivateIndex)"
   #important to define GIT_INDEX_FILE as local: This way it only affects this function (and below) - even with the export afterwards
   local GIT_INDEX_FILE
@@ -513,7 +519,9 @@ function updatePrompt() {
         v="\$GIT_$1 $2"
       fi
       if eval "test $v" ; then
-        if [[ $# -lt 2 || "$3" != '-' ]]; then
+        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" ]]; then
+           __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
+        elif [[ $# -lt 2 || "$3" != '-' ]] && [[ "${__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" -eq "1" ]]; then
           __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
         else
           __add_status "\$GIT_PROMPT_$1\$ResetColor"

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -519,10 +519,8 @@ function updatePrompt() {
         v="\$GIT_$1 $2"
       fi
       if eval "test $v" ; then
-        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" ]]; then
+        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" || "${__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" -eq "1" ]]; then
            __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
-        elif [[ $# -lt 2 || "$3" != '-' ]] && [[ "${__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" -eq "1" ]]; then
-          __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
         else
           __add_status "\$GIT_PROMPT_$1\$ResetColor"
         fi

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -519,7 +519,7 @@ function updatePrompt() {
         v="\$GIT_$1 $2"
       fi
       if eval "test $v" ; then
-        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" || "x$__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT" == "x1" ]]; then
+        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT" == "x1" || "x$1" == "xREMOTE" ]]; then
           __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
         else
           __add_status "\$GIT_PROMPT_$1\$ResetColor"

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -520,7 +520,7 @@ function updatePrompt() {
       fi
       if eval "test $v" ; then
         if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" || "${__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" -eq "1" ]]; then
-           __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
+          __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
         else
           __add_status "\$GIT_PROMPT_$1\$ResetColor"
         fi

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -519,7 +519,7 @@ function updatePrompt() {
         v="\$GIT_$1 $2"
       fi
       if eval "test $v" ; then
-        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" || "${__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT}" -eq "1" ]]; then
+        if [[ $# -lt 2 || "$3" != '-' ]] && [[ "x$1" == "xREMOTE" || "x$__GIT_PROMPT_SHOW_CHANGED_FILES_COUNT" == "x1" ]]; then
           __add_status "\$GIT_PROMPT_$1\$GIT_$1\$ResetColor"
         else
           __add_status "\$GIT_PROMPT_$1\$ResetColor"


### PR DESCRIPTION
In #279 there was a question whether you could disable the number of changed files and leave only the icons.

This pr should apply that feature.

To disable the numbers you set

 `GIT_PROMPT_SHOW_CHANGED_FILES_COUNT=0`

before sourcing gitprompt.sh