### PR TITLE
Fix gitstatus.sh to produce output when ran standalone

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -15,7 +15,7 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-gitstatus=$( LC_ALL=C git status --untracked-files=${__GIT_PROMPT_SHOW_UNTRACKED_FILES} --porcelain --branch )
+gitstatus=$( LC_ALL=C git status --untracked-files=${__GIT_PROMPT_SHOW_UNTRACKED_FILES:-all} --porcelain --branch )
 
 # if the status is fatal, exit now
 [[ "$?" -ne 0 ]] && exit 0


### PR DESCRIPTION
This lets you run gitstatus.sh without the variable set, this is useful if you are debugging and just want to check the output of gitstatus.sh.