### PR TITLE
extend gp_truncate_pwd to accept parameter with max pwd length

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ function prompt_callback {
 
 - There are two helper functions that can be used within `prompt_callback`:
     - `gp_set_window_title <String>` - sets the window title to the given string (should work for XTerm type terminals like in OS X or Ubuntu)
-    - `gp_truncate_pwd` - a function that returns the current PWD truncated to fit the current terminal width
+    - `gp_truncate_pwd` - a function that returns the current PWD truncated to fit the current terminal width. Specify the length to truncate to as a parameter. Otherwise it defaults to 1/3 of the terminal width.
 
 - If you want to show the git prompt only if you are in a git repository you
   can set ``GIT_PROMPT_ONLY_IN_REPO=1`` before sourcing the gitprompt script

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -585,10 +585,11 @@ function is_function {
 }
 
 # Helper function that truncates $PWD depending on window width
+# Optionally specify maximum length as parameter (defaults to 1/3 of terminal)
 function gp_truncate_pwd {
   local tilde="~"
   local newPWD="${PWD/#${HOME}/${tilde}}"
-  local pwdmaxlen=$((${COLUMNS:-80}/3))
+  local pwdmaxlen=${1:-$((${COLUMNS:-80}/3))}
   [ ${#newPWD} -gt $pwdmaxlen ] && newPWD="...${newPWD:3-$pwdmaxlen}"
   echo -n "$newPWD"
 }


### PR DESCRIPTION
If length is passed as a parameter, the given length will be used to truncate the pwd. If nothing is specified it defaults to 1/3 of the terminal width.

This enables themes (including mine) to more effectively use the available terminal width.