### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The symbols are as follows:
   - ``✔``: repository clean
   - ``●n``: there are ``n`` staged files
   - ``✖n``: there are ``n`` files with merge conflicts
+  - ``✖-n``: there are ``n`` staged files wayting for removal
   - ``✚n``: there are ``n`` changed but *unstaged* files
   - ``…n``: there are ``n`` untracked files
   - ``⚑n``: there are ``n`` stash entries


### PR DESCRIPTION
added ✖-n for staged files state after command `git-rm`. I do not know if my explanation is okay, so feel free to rephrase.