### PR TITLE
[security] Fix for #310

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -496,11 +496,11 @@ function updatePrompt() {
     unset GIT_REMOTE
   fi
 
-  local GIT_UPSTREAM="${git_status_fields[2]}"
+  export GIT_UPSTREAM="${git_status_fields[2]}"
+  local GIT_FORMATTED_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/\$GIT_UPSTREAM}"
   if [[ -z "${__GIT_PROMPT_SHOW_UPSTREAM}" || "^" == "$GIT_UPSTREAM" ]]; then
     unset GIT_UPSTREAM
-  else
-    GIT_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/${GIT_UPSTREAM}}"
+    unset GIT_FORMATTED_UPSTREAM
   fi
 
   local GIT_STAGED=${git_status_fields[3]}
@@ -512,7 +512,8 @@ function updatePrompt() {
 
   local NEW_PROMPT="$EMPTY_PROMPT"
   if [[ -n "$git_status_fields" ]]; then
-    local STATUS="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}${GIT_BRANCH}${ResetColor}"
+    local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+    local STATUS=""
 
     # __add_status KIND VALEXPR INSERT
     # eg: __add_status  'STAGED' '-ne 0'
@@ -542,7 +543,6 @@ function updatePrompt() {
       eval "STATUS=\"$STATUS$1\""
     }
 
-    __add_status        '$GIT_UPSTREAM'
     __chk_gitvar_status 'REMOTE'     '-n'
     __add_status        "$GIT_PROMPT_SEPARATOR"
     __chk_gitvar_status 'STAGED'     '-ne 0'
@@ -553,7 +553,7 @@ function updatePrompt() {
     __chk_gitvar_status 'CLEAN'      '-eq 1'   -
     __add_status        "$ResetColor$GIT_PROMPT_SUFFIX"
 
-    NEW_PROMPT="$(gp_add_virtualenv_to_prompt)$PROMPT_START$($prompt_callback)$STATUS$PROMPT_END"
+    NEW_PROMPT="$(gp_add_virtualenv_to_prompt)$PROMPT_START$($prompt_callback)$STATUS_PREFIX$STATUS$PROMPT_END"
   else
     NEW_PROMPT="$EMPTY_PROMPT"
   fi

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -497,10 +497,11 @@ function updatePrompt() {
   fi
 
   export GIT_UPSTREAM="${git_status_fields[2]}"
-  local GIT_FORMATTED_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/\$GIT_UPSTREAM}"
   if [[ -z "${__GIT_PROMPT_SHOW_UPSTREAM}" || "^" == "$GIT_UPSTREAM" ]]; then
     unset GIT_UPSTREAM
     unset GIT_FORMATTED_UPSTREAM
+  else
+    local GIT_FORMATTED_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/\$GIT_UPSTREAM}"
   fi
 
   local GIT_STAGED=${git_status_fields[3]}

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -496,10 +496,11 @@ function updatePrompt() {
     unset GIT_REMOTE
   fi
 
-  export GIT_UPSTREAM="${git_status_fields[2]}"
-  if [[ -z "${__GIT_PROMPT_SHOW_UPSTREAM}" || "^" == "$GIT_UPSTREAM" ]]; then
+  local GIT_UPSTREAM_PRIVATE="${git_status_fields[2]}"
+  if [[ -z "${__GIT_PROMPT_SHOW_UPSTREAM}" || "^" == "$GIT_UPSTREAM_PRIVATE" ]]; then
     unset GIT_UPSTREAM
   else
+    export GIT_UPSTREAM=${GIT_UPSTREAM_PRIVATE}
     local GIT_FORMATTED_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/\$GIT_UPSTREAM}"
   fi
 

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -499,7 +499,6 @@ function updatePrompt() {
   export GIT_UPSTREAM="${git_status_fields[2]}"
   if [[ -z "${__GIT_PROMPT_SHOW_UPSTREAM}" || "^" == "$GIT_UPSTREAM" ]]; then
     unset GIT_UPSTREAM
-    unset GIT_FORMATTED_UPSTREAM
   else
     local GIT_FORMATTED_UPSTREAM="${GIT_PROMPT_UPSTREAM//_UPSTREAM_/\$GIT_UPSTREAM}"
   fi


### PR DESCRIPTION
The approach is to wait with evaluation of the parts that contain the branch names until PS1 is rendered.

This patch handles both the ordinary branch name as well as the upstream branch name.

Try to fix #310.

Credits to @chmike and @jayrhynas

Steps to reproduce the bug and see if the fix works:

```sh
git clone https://github.com/njhartwell/pw3nage.git
cd pw3nage
GIT_PROMPT_SHOW_UPSTREAM=1
unset GIT_PROMPT_SHOW_UPSTREAM
```

Expected result when fixed without upstream info:

```sh
[$(./pw3n)|✔] ✔
```

With upstream info:

```sh
[$(./pw3n) {origin/$(./pw3n)}|✔] ✔
```