### PR TITLE
Support repo exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Add to the `~/.bashrc`:
    # Set config variables first
    GIT_PROMPT_ONLY_IN_REPO=1
 
+   # # When GIT_PROMPT_ONLY_IN_REPO is 1, gitprompt can be selectively disabled for certain
+   # # repositories by setting GIT_PROMPT_REPO_EXCLUSIONS.
+   # # (Provided repository names should be in `git rev-parse --show-toplevel` format)
+   # GIT_PROMPT_REPO_EXCLUSIONS="/home/myname /some/other"  # repos separated by space
+
    # GIT_PROMPT_FETCH_REMOTE_STATUS=0   # uncomment to avoid fetching remote status
 
    # GIT_PROMPT_SHOW_UPSTREAM=1 # uncomment to show upstream tracking branch

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -320,10 +320,18 @@ function setGitPrompt() {
   update_old_git_prompt
 
   local repo=$(git rev-parse --show-toplevel 2> /dev/null)
-  if [[ ! -e "$repo" ]] && [[ "$GIT_PROMPT_ONLY_IN_REPO" = 1 ]]; then
-    # we do not permit bash-git-prompt outside git repos, so nothing to do
-    PS1="$OLD_GITPROMPT"
-    return
+  if [[ "$GIT_PROMPT_ONLY_IN_REPO" = 1 ]]; then
+    if [[ ! -e "$repo" ]]; then
+      # we do not permit bash-git-prompt outside git repos, so nothing to do
+      PS1="$OLD_GITPROMPT"
+      return
+    fi
+    for exclude_repo in $GIT_PROMPT_REPO_EXCLUSIONS; do
+      if [[ "$repo" == "$exclude_repo" ]]; then
+        PS1="$OLD_GITPROMPT"
+        return
+      fi
+    done
   fi
 
   local EMPTY_PROMPT


### PR DESCRIPTION
* Support $GIT_PROMPT_REPO_EXCLUSIONS for disabling git prompt within
  repositories (e.g. $HOME) for which a vanilla prompt is more desirable
  than a git prompt.