### PR TITLE
Ahead/Behind only if actually ahead/behind

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -86,11 +86,11 @@ else
     IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
     upstream="${remote_fields[0]}"
     for remote_field in "${remote_fields[@]}"; do
-      if [[ "$remote_field" == *ahead* ]]; then
+      if [[ "$remote_field" == ahead ]]; then
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == *behind* ]]; then
+      if [[ "$remote_field" == behind ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -86,11 +86,11 @@ else
     IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
     upstream="${remote_fields[0]}"
     for remote_field in "${remote_fields[@]}"; do
-      if [[ "$remote_field" == ahead ]]; then
+      if [[ "$remote_field" == "ahead "* ]]; then
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == behind ]]; then
+      if [[ "$remote_field" == "behind "* ]] || [[ "$remote_field" == " behind "* ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi


### PR DESCRIPTION
* Previously status was also displayed, when branch name contained 'ahead' or 'behind'