### PR TITLE
[security] Check the syntax of .bash-git-rc before sourcing it

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -346,7 +346,13 @@ function setGitPrompt() {
   unset GIT_PROMPT_SHOW_UNTRACKED_FILES
 
   if [[ -e "$repo/.bash-git-rc" ]]; then
-    source "$repo/.bash-git-rc"
+    # The config file can only contain variable declarations on the form A_B=0 or G_P=all
+    local CONFIG_SYNTAX="^[A-Z_]+=[0-9a-z]+$"
+    if egrep -q -v "$CONFIG_SYNTAX" "$repo/.bash-git-rc"; then
+      echo ".bash-git-rc can only contain variable values on the form NAME=value. Ignoring file." >&2
+    else
+      source "$repo/.bash-git-rc"
+    fi
   fi
 
   if [ -z "${GIT_PROMPT_SHOW_UNTRACKED_FILES}" ]; then

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -347,7 +347,7 @@ function setGitPrompt() {
 
   if [[ -e "$repo/.bash-git-rc" ]]; then
     # The config file can only contain variable declarations on the form A_B=0 or G_P=all
-    local CONFIG_SYNTAX="^[A-Z_]+=[0-9a-z]+$"
+    local CONFIG_SYNTAX="^(FETCH_REMOTE_STATUS|GIT_PROMPT_SHOW_UNTRACKED_FILES|GIT_PROMPT_IGNORE)=[0-9a-z]+$"
     if egrep -q -v "$CONFIG_SYNTAX" "$repo/.bash-git-rc"; then
       echo ".bash-git-rc can only contain variable values on the form NAME=value. Ignoring file." >&2
     else


### PR DESCRIPTION
Try to fix #324.
Let the `.bash-git-rc`-file only contain variable declarations on the form

`^(FETCH_REMOTE_STATUS|GIT_PROMPT_SHOW_UNTRACKED_FILES|GIT_PROMPT_IGNORE)=[0-9a-z]+$`

E.g `FETCH_REMOTE_STATUS=0`
`GIT_PROMPT_SHOW_UNTRACKED_FILES=all`