### PR TITLE
Add mercurial-support

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -26,12 +26,12 @@ function echoc() {
 
 function get_theme() {
   local CUSTOM_THEME_FILE="${HOME}/.git-prompt-colors.sh"
-  if [[ ! (-z ${GIT_PROMPT_THEME_FILE} ) ]]; then
+  if [[ ! (-z ${GIT_PROMPT_THEME_FILE:-} ) ]]; then
     CUSTOM_THEME_FILE=$GIT_PROMPT_THEME_FILE
   fi
   local DEFAULT_THEME_FILE="${__GIT_PROMPT_DIR}/themes/Default.bgptheme"
 
-  if [[ -z ${GIT_PROMPT_THEME} ]]; then
+  if [[ -z ${GIT_PROMPT_THEME:-} ]]; then
     if [[ -r $CUSTOM_THEME_FILE ]]; then
       GIT_PROMPT_THEME="Custom"
       __GIT_PROMPT_THEME_FILE=$CUSTOM_THEME_FILE
@@ -145,6 +145,7 @@ function git_prompt_make_custom_theme() {
 # Return 0 (success) if ENVAR not already defined, 1 (failure) otherwise.
 
 function gp_set_file_var() {
+  trap "set -$-" RETURN; set +o nounset
   local envar="$1"
   local file="$2"
   if eval "[[ -n \"\$$envar\" && -r \"\$$envar\" ]]" ; then # is envar set to a readable file?
@@ -211,6 +212,7 @@ gp_format_exit_status() {
 }
 
 function git_prompt_config() {
+  trap "set -$-" RETURN; set +o nounset
   #Checking if root to change output
   _isroot=false
   [[ $UID -eq 0 ]] && _isroot=true

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -15,89 +15,133 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
-gitstatus=$( LC_ALL=C git status --untracked-files=${__GIT_PROMPT_SHOW_UNTRACKED_FILES:-all} --porcelain --branch )
+function git_status() {
+    gitstatus=$( LC_ALL=C git status --untracked-files=${__GIT_PROMPT_SHOW_UNTRACKED_FILES:-all} --porcelain --branch )
+    # if the status is fatal, exit now
+    [[ "$?" -ne 0 ]] && exit 0
 
-# if the status is fatal, exit now
-[[ "$?" -ne 0 ]] && exit 0
+    num_staged=0
+    num_changed=0
+    num_conflicts=0
+    num_untracked=0
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        status=${line:0:2}
+        while [[ -n $status ]]; do
+            case "$status" in
+                #two fixed character matches, loop finished
+                \#\#) branch_line="${line/\.\.\./^}"; break ;;
+                \?\?) ((num_untracked++)); break ;;
+                U?) ((num_conflicts++)); break;;
+                ?U) ((num_conflicts++)); break;;
+                DD) ((num_conflicts++)); break;;
+                AA) ((num_conflicts++)); break;;
+                #two character matches, first loop
+                ?M) ((num_changed++)) ;;
+                ?D) ((num_changed++)) ;;
+                ?\ ) ;;
+                #single character matches, second loop
+                U) ((num_conflicts++)) ;;
+                \ ) ;;
+                *) ((num_staged++)) ;;
+            esac
+            status=${status:0:(${#status}-1)}
+        done
+    done <<< "$gitstatus"
 
-num_staged=0
-num_changed=0
-num_conflicts=0
-num_untracked=0
-while IFS='' read -r line || [[ -n "$line" ]]; do
-  status=${line:0:2}
-  while [[ -n $status ]]; do
-    case "$status" in
-      #two fixed character matches, loop finished
-      \#\#) branch_line="${line/\.\.\./^}"; break ;;
-      \?\?) ((num_untracked++)); break ;;
-      U?) ((num_conflicts++)); break;;
-      ?U) ((num_conflicts++)); break;;
-      DD) ((num_conflicts++)); break;;
-      AA) ((num_conflicts++)); break;;
-      #two character matches, first loop
-      ?M) ((num_changed++)) ;;
-      ?D) ((num_changed++)) ;;
-      ?\ ) ;;
-      #single character matches, second loop
-      U) ((num_conflicts++)) ;;
-      \ ) ;;
-      *) ((num_staged++)) ;;
-    esac
-    status=${status:0:(${#status}-1)}
-  done
-done <<< "$gitstatus"
+    num_stashed=0
+    if [[ "$__GIT_PROMPT_IGNORE_STASH" != "1" ]]; then
+      stash_file="$( git rev-parse --git-dir )/logs/refs/stash"
+      if [[ -e "${stash_file}" ]]; then
+        while IFS='' read -r wcline || [[ -n "$wcline" ]]; do
+            ((num_stashed++))
+        done < ${stash_file}
+      fi
+    fi
 
-num_stashed=0
-if [[ "$__GIT_PROMPT_IGNORE_STASH" != "1" ]]; then
-  stash_file="$( git rev-parse --git-dir )/logs/refs/stash"
-  if [[ -e "${stash_file}" ]]; then
-    while IFS='' read -r wcline || [[ -n "$wcline" ]]; do
-      ((num_stashed++))
-    done < ${stash_file}
-  fi
-fi
+    clean=0
+    if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed == 0 && num_conflicts == 0)) ; then
+      clean=1
+    fi
 
-clean=0
-if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed == 0 && num_conflicts == 0)) ; then
-  clean=1
-fi
+    IFS="^" read -ra branch_fields <<< "${branch_line/\#\# }"
+    branch="${branch_fields[0]}"
+    remote=
+    upstream=
 
-IFS="^" read -ra branch_fields <<< "${branch_line/\#\# }"
-branch="${branch_fields[0]}"
-remote=
-upstream=
+    if [[ "$branch" == *"Initial commit on"* ]]; then
+      IFS=" " read -ra fields <<< "$branch"
+      branch="${fields[3]}"
+      remote="_NO_REMOTE_TRACKING_"
+    elif [[ "$branch" == *"no branch"* ]]; then
+      tag=$( git describe --tags --exact-match )
+      if [[ -n "$tag" ]]; then
+        branch="$tag"
+      else
+          branch="_PREHASH_$( git rev-parse --short HEAD )"
+      fi
+    else
+        if [[ "${#branch_fields[@]}" -eq 1 ]]; then
+          remote="_NO_REMOTE_TRACKING_"
+        else
+            IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
+            upstream="${remote_fields[0]}"
+            for remote_field in "${remote_fields[@]}"; do
+                if [[ "$remote_field" == *ahead* ]]; then
+                  num_ahead=${remote_field:6}
+                  ahead="_AHEAD_${num_ahead}"
+                fi
+                if [[ "$remote_field" == *behind* ]]; then
+                  num_behind=${remote_field:7}
+                  behind="_BEHIND_${num_behind# }"
+                fi
+            done
+            remote="${behind}${ahead}"
+        fi
+    fi
+}
 
-if [[ "$branch" == *"Initial commit on"* ]]; then
-  IFS=" " read -ra fields <<< "$branch"
-  branch="${fields[3]}"
-  remote="_NO_REMOTE_TRACKING_"
-elif [[ "$branch" == *"no branch"* ]]; then
-  tag=$( git describe --tags --exact-match )
-  if [[ -n "$tag" ]]; then
-    branch="$tag"
-  else
-    branch="_PREHASH_$( git rev-parse --short HEAD )"
-  fi
-else
-  if [[ "${#branch_fields[@]}" -eq 1 ]]; then
+function hg_status() {
+    branch="$(LC_ALL=C hg branch)"
+
+    num_changed=0
+    num_untracked=0
+    clean=1
+    while IFS='' read -r line; do
+        case "${line:0:1}" in
+            '?') ((num_untracked++)); clean=0;;
+            'M') ((num_changed++)); clean=0;;
+            '!') ((num_changed++)); clean=0;;
+            'A') ((num_changed++)); clean=0;;
+            'R') ((num_changed++)); clean=0;;
+        esac
+    done < <( LC_ALL=C hg status )
+
     remote="_NO_REMOTE_TRACKING_"
-  else
-    IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
-    upstream="${remote_fields[0]}"
-    for remote_field in "${remote_fields[@]}"; do
-      if [[ "$remote_field" == *ahead* ]]; then
-        num_ahead=${remote_field:6}
-        ahead="_AHEAD_${num_ahead}"
-      fi
-      if [[ "$remote_field" == *behind* ]]; then
-        num_behind=${remote_field:7}
-        behind="_BEHIND_${num_behind# }"
-      fi
-    done
-    remote="${behind}${ahead}"
-  fi
+    upstream="$(hg paths default)"
+    upstream="${upstream#*//}"
+    upstream="${upstream#*@}"
+
+    if [ -n "$upstream" ]; then
+      ahead="$(hg log -r 'draft()' | grep -c '^changeset:')"
+      [[ "$ahead" > 0 ]] && remote="_AHEAD_${ahead}"
+      behind="$(< $(hg root 2>/dev/null)/.hg/git-prompt-incoming)"
+      [[ "$behind" > 0 ]] && remote="_BEHIND_${ahead}${remote}"
+    fi
+
+    num_staged=0
+    num_conflicts=0
+    num_stashed=0
+}
+
+gitroot="$(git rev-parse --show-toplevel 2>/dev/null)"
+hgroot="$(hg root 2>/dev/null)"
+
+if [ "${#hgroot}" -gt "${#gitroot}" ]; then
+  hg_status
+else
+    git_status
 fi
+
 
 if [[ -z "$remote" ]] ; then
   remote='.'

--- a/prompt-colors.sh
+++ b/prompt-colors.sh
@@ -60,7 +60,7 @@ define_color_names() {
   # def_color NAME ATTRCODE COLORCODE
   _def_color() {
     local def="$1=\"\`_term_color $2 $3\`\""
-    if [[ -n "$debug$verbose" ]]; then
+    if [[ -n "${debug-}${verbose-}" ]]; then
       echo 1>&2 "+ $def"
     fi
     eval "$def"
@@ -77,6 +77,4 @@ define_color_names() {
 }
 
 # do the color definitions only once
-if [[ ${#ColorNames[*]} = 0 || -z "$IntenseBlack" || -z "$ResetColor" ]]; then
-  define_color_names
-fi
+[ -z "${ResetColor-}" ] && define_color_names

--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -92,7 +92,7 @@ define_undefined_git_prompt_colors() {
 
 # call only from theme file
 reload_git_prompt_colors() {
-  if [[ "${GIT_PROMPT_THEME_NAME}" != $1 ]]; then
+  if [[ "${GIT_PROMPT_THEME_NAME:-}" != $1 ]]; then
     unset_git_prompt_colors
     define_helpers
     override_git_prompt_colors


### PR DESCRIPTION
This addresses #222. The set of displayable information is not exactly the same due to differences in how hg and git work, but this comes close and displays other useful information in places where hg differs from git.

Sorry for trashing gitstatus.sh, wrapping the existing code in a function seemed to be the easiest way.