### PR TITLE
change root prompt to reset color at the end on Single_line_Solarized

### DIFF
--- a/themes/Single_line_Solarized.bgptheme
+++ b/themes/Single_line_Solarized.bgptheme
@@ -26,7 +26,7 @@ override_git_prompt_colors() {
 
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"
   GIT_PROMPT_END_USER="${BoldBlue} ➭ ${ResetColor}"
-  GIT_PROMPT_END_ROOT="${BoldRed} # "
+  GIT_PROMPT_END_ROOT="${BoldRed} # ${ResetColor}"
 
   GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="✭"
 }


### PR DESCRIPTION
this commit updates Single_line_Solarized.bgptheme to reset the root prompt color at the end of the prompt string

before this commit, the root prompt would not reset the terminal text color so it would remain red.

The reason for this change is that having all output in red, makes it harder to sport error messages in  applications that use colors to highlight status