### PR TITLE
Git 2.14 compatibility. Also add separator to status only if something follows it

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -551,13 +551,15 @@ function updatePrompt() {
     }
 
     __chk_gitvar_status 'REMOTE'     '-n'
-    __add_status        "$GIT_PROMPT_SEPARATOR"
-    __chk_gitvar_status 'STAGED'     '-ne 0'
-    __chk_gitvar_status 'CONFLICTS'  '-ne 0'
-    __chk_gitvar_status 'CHANGED'    '-ne 0'
-    __chk_gitvar_status 'UNTRACKED'  '-ne 0'
-    __chk_gitvar_status 'STASHED'    '-ne 0'
-    __chk_gitvar_status 'CLEAN'      '-eq 1'   -
+    if [[ $GIT_CLEAN -eq 0 ]] || [[ $GIT_PROMPT_CLEAN != "" ]]; then
+      __add_status        "$GIT_PROMPT_SEPARATOR"
+      __chk_gitvar_status 'STAGED'     '-ne 0'
+      __chk_gitvar_status 'CONFLICTS'  '-ne 0'
+      __chk_gitvar_status 'CHANGED'    '-ne 0'
+      __chk_gitvar_status 'UNTRACKED'  '-ne 0'
+      __chk_gitvar_status 'STASHED'    '-ne 0'
+      __chk_gitvar_status 'CLEAN'      '-eq 1'   -
+    fi
     __add_status        "$ResetColor$GIT_PROMPT_SUFFIX"
 
     NEW_PROMPT="$(gp_add_virtualenv_to_prompt)$PROMPT_START$($prompt_callback)$STATUS_PREFIX$STATUS$PROMPT_END"

--- a/gitstatus.py
+++ b/gitstatus.py
@@ -89,6 +89,8 @@ for st in status:
     if st[0] == '#' and st[1] == '#':
         if re.search('Initial commit on', st[2]):
             branch = st[2].split(' ')[-1]
+        elif re.search('No commits yet on', st[2]):
+            branch = st[2].split(' ')[-1]
         elif re.search('no branch', st[2]):  # detached status
             branch = get_tag_or_hash()
         elif len(st[2].strip().split('...')) == 1:
@@ -150,4 +152,3 @@ if python_version == 2:
     Print(out.encode('utf-8'))
 else:
     Print(out)
-

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -72,6 +72,10 @@ if [[ "$branch" == *"Initial commit on"* ]]; then
   IFS=" " read -ra fields <<< "$branch"
   branch="${fields[3]}"
   remote="_NO_REMOTE_TRACKING_"
+elif [[ "$branch" == *"No commits yet on"* ]]; then
+  IFS=" " read -ra fields <<< "$branch"
+  branch="${fields[4]}"
+  remote="_NO_REMOTE_TRACKING_"
 elif [[ "$branch" == *"no branch"* ]]; then
   tag=$( git describe --tags --exact-match )
   if [[ -n "$tag" ]]; then


### PR DESCRIPTION
When `GIT_PROMPT_CLEAN=""`, it leads to a dangling separator at the end when the state is clean.

The commit fixes that by adding the separator only when something will follow after it.
