### PR TITLE
Fixed Chmike reload call

### DIFF
--- a/themes/Chmike.bgptheme
+++ b/themes/Chmike.bgptheme
@@ -28,4 +28,4 @@ override_git_prompt_colors() {
   GIT_PROMPT_COMMAND_FAIL="${Red}✘"
 }
 
-reload_git_prompt_colors "Crunch"
+reload_git_prompt_colors "Chmike"


### PR DESCRIPTION
reload_git_prompt_colors used 'Crunch' instead of 'Chmike'. This fixes it.