### PR TITLE
Fishfix

### DIFF
--- a/gitprompt.fish
+++ b/gitprompt.fish
@@ -1,43 +1,43 @@
 # name: bash-git-prompt
 # author: Mariusz Smykuła <mariuszs@gmail.com>
 
-if not set -q __GIT_PROMPT_DIR
-    set __GIT_PROMPT_DIR ~/.bash-git-prompt
-end
-
-# Colors
-# Reset
-set ResetColor (set_color normal)       # Text Reset
-
-# Regular Colors
-set Red (set_color red)                 # Red
-set Yellow (set_color yellow);          # Yellow
-set Blue (set_color blue)               # Blue
-set WHITE (set_color white)
-
-# Bold
-set BGreen (set_color -o green)         # Green
-
-# High Intensty
-set IBlack (set_color -o black)         # Black
-
-# Bold High Intensty
-set Magenta (set_color -o purple)       # Purple
-
-# Default values for the appearance of the prompt. Configure at will.
-set GIT_PROMPT_PREFIX "["
-set GIT_PROMPT_SUFFIX "]"
-set GIT_PROMPT_SEPARATOR "|"
-set GIT_PROMPT_BRANCH "$Magenta"
-set GIT_PROMPT_STAGED "$Red● "
-set GIT_PROMPT_CONFLICTS "$Red✖ "
-set GIT_PROMPT_CHANGED "$Blue✚ "
-set GIT_PROMPT_REMOTE " "
-set GIT_PROMPT_UNTRACKED "…"
-set GIT_PROMPT_STASHED "⚑ "
-set GIT_PROMPT_CLEAN "$BGreen✔"
-
 function fish_prompt
+
+    if not set -q __GIT_PROMPT_DIR
+        set __GIT_PROMPT_DIR ~/.bash-git-prompt
+    end
+
+    # Colors
+    # Reset
+    set ResetColor (set_color normal)       # Text Reset
+
+    # Regular Colors
+    set Red (set_color red)                 # Red
+    set Yellow (set_color yellow);          # Yellow
+    set Blue (set_color blue)               # Blue
+    set WHITE (set_color white)
+
+    # Bold
+    set BGreen (set_color -o green)         # Green
+
+    # High Intensty
+    set IBlack (set_color -o black)         # Black
+
+    # Bold High Intensty
+    set Magenta (set_color -o purple)       # Purple
+
+    # Default values for the appearance of the prompt. Configure at will.
+    set GIT_PROMPT_PREFIX "["
+    set GIT_PROMPT_SUFFIX "]"
+    set GIT_PROMPT_SEPARATOR "|"
+    set GIT_PROMPT_BRANCH "$Magenta"
+    set GIT_PROMPT_STAGED "$Red● "
+    set GIT_PROMPT_CONFLICTS "$Red✖ "
+    set GIT_PROMPT_CHANGED "$Blue✚ "
+    set GIT_PROMPT_REMOTE " "
+    set GIT_PROMPT_UNTRACKED "…"
+    set GIT_PROMPT_STASHED "⚑ "
+    set GIT_PROMPT_CLEAN "$BGreen✔"
 
     # Various variables you might want for your PS1 prompt instead
     set Time (date +%R)
@@ -92,7 +92,7 @@ function fish_prompt
         if [ "$GIT_UNTRACKED" != "0" ]
             set STATUS "$STATUS$GIT_PROMPT_UNTRACKED$GIT_UNTRACKED$ResetColor"
         end
-        
+
         if [ "$GIT_STASHED" != "0" ]
             set STATUS "$STATUS$GIT_PROMPT_STASHED$GIT_STASHED$ResetColor"
         end

--- a/gitprompt.fish
+++ b/gitprompt.fish
@@ -2,7 +2,7 @@
 # author: Mariusz Smykuła <mariuszs@gmail.com>
 
 if not set -q __GIT_PROMPT_DIR
-    set __GIT_PROMPT_DIR ~/.gitprompt
+    set __GIT_PROMPT_DIR ~/.bash-git-prompt
 end
 
 # Colors


### PR DESCRIPTION
All of the `gitprompt.fish` file's content must be in the body of `fish_prompt` function. [Fish webconfig uses](https://github.com/fish-shell/fish-shell/blob/2.6.0/share/tools/web_config/webconfig.py#L739) [`funcsave` command](https://fishshell.com/docs/current/commands.html#funcsave) to install the selected prompt. As a result prompt configuration saved by webconfig is incomplete and cause some errors, e.g. invalid path to the `gitstatus.py` file because of not set `__GIT_PROMPT_DIR`.