### PR TITLE
Allow different color for master branch

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -519,7 +519,15 @@ function updatePrompt() {
 
   local NEW_PROMPT="$EMPTY_PROMPT"
   if [[ -n "$git_status_fields" ]]; then
-    local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+
+    case "$GIT_BRANCH" in
+      $GIT_PROMPT_MASTER_BRANCHES)
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_MASTER_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        ;;
+      *)
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        ;;
+    esac
     local STATUS=""
 
     # __add_status KIND VALEXPR INSERT

--- a/themes/Chmike.bgptheme
+++ b/themes/Chmike.bgptheme
@@ -14,6 +14,7 @@ override_git_prompt_colors() {
 
   GIT_PROMPT_THEME_NAME="Chmike"
   GIT_PROMPT_BRANCH="${Green}"
+  GIT_PROMPT_MASTER_BRANCH="${Green}"
   GIT_PROMPT_REMOTE=" "
   GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="⭐"
 

--- a/themes/Custom.bgptemplate
+++ b/themes/Custom.bgptemplate
@@ -14,6 +14,7 @@ override_git_prompt_colors() {
   # GIT_PROMPT_SEPARATOR="|"              # separates each item
 
   # GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
+  # GIT_PROMPT_MASTER_BRANCH="${Magenta}" # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
   # GIT_PROMPT_STAGED="${Red}●"           # the number of staged files/directories
   # GIT_PROMPT_CONFLICTS="${Red}✖ "       # the number of files in conflict
   # GIT_PROMPT_CHANGED="${Blue}✚ "        # the number of changed files
@@ -53,6 +54,12 @@ override_git_prompt_colors() {
   # GIT_PROMPT_SYMBOLS_BEHIND="↓·"            # The symbol for "n versions behind of origin"
   # GIT_PROMPT_SYMBOLS_PREHASH=":"            # Written before hash of commit, if no name could be found
   # GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L" # This symbol is written after the branch, if the branch is not tracked 
+
+  # branch name(s) that will use $GIT_PROMPT_MASTER_BRANCH color
+  # To specify multiple branches, use
+  #   shopt -s extglob
+  #   GIT_PROMPT_MASTER_BRANCHES='@(master|production)'
+  # GIT_PROMPT_MASTER_BRANCHES="master"
 }
 
 reload_git_prompt_colors "Custom"

--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -42,6 +42,7 @@ define_undefined_git_prompt_colors() {
   if [ -z ${GIT_PROMPT_SEPARATOR+x} ]; then GIT_PROMPT_SEPARATOR="|"; fi              # separates each item
 
   if [ -z ${GIT_PROMPT_BRANCH+x} ]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
+  if [ -z ${GIT_PROMPT_MASTER_BRANCH+x} ]; then GIT_PROMPT_MASTER_BRANCH="${Magenta}"; fi  # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
   if [ -z ${GIT_PROMPT_STAGED+x} ]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
   if [ -z ${GIT_PROMPT_CONFLICTS+x} ]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
   if [ -z ${GIT_PROMPT_CHANGED+x} ]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
@@ -88,6 +89,12 @@ define_undefined_git_prompt_colors() {
   if [ -z ${GIT_PROMPT_SYMBOLS_BEHIND+x} ]; then GIT_PROMPT_SYMBOLS_BEHIND="↓·"; fi            # The symbol for "n versions behind of origin"
   if [ -z ${GIT_PROMPT_SYMBOLS_PREHASH+x} ]; then GIT_PROMPT_SYMBOLS_PREHASH=":"; fi            # Written before hash of commit, if no name could be found
   if [ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING+x} ]; then GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"; fi # This symbol is written after the branch, if the branch is not tracked
+
+  # branch name(s) that will use $GIT_PROMPT_MASTER_BRANCH color
+  # To specify multiple branches, use
+  #   shopt -s extglob
+  #   GIT_PROMPT_MASTER_BRANCHES='@(master|production)'
+  if [ -z ${GIT_PROMPT_MASTER_BRANCHES+x} ]; then GIT_PROMPT_MASTER_BRANCHES="master"; fi
 }
 
 # call only from theme file

--- a/themes/Evermeet.bgptheme
+++ b/themes/Evermeet.bgptheme
@@ -9,6 +9,7 @@ override_git_prompt_colors() {
 	GIT_PROMPT_SEPARATOR="|"              # separates each item
 
 	GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
+	GIT_PROMPT_MASTER_BRANCH="${Magenta}" # the git branch that is active in the current directory
 	GIT_PROMPT_STAGED="${Cyan}●"          # the number of staged files/directories
 	GIT_PROMPT_CONFLICTS="${BoldRed}✖"    # the number of files in conflict
 	GIT_PROMPT_CHANGED="${Cyan}✚"         # the number of changed files

--- a/themes/Evermeet_Lowres.bgptheme
+++ b/themes/Evermeet_Lowres.bgptheme
@@ -11,6 +11,7 @@ override_git_prompt_colors() {
 	GIT_PROMPT_SEPARATOR="|"              # separates each item
 
 	GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
+	GIT_PROMPT_MASTER_BRANCH="${Magenta}" # the git branch that is active in the current directory
 	GIT_PROMPT_STAGED="${Cyan}●"          # the number of staged files/directories
 	GIT_PROMPT_CONFLICTS="${BoldRed}✖ "   # the number of files in conflict
 	GIT_PROMPT_CHANGED="${Cyan}✚ "        # the number of changed files

--- a/themes/Evermeet_Ubuntu.bgptheme
+++ b/themes/Evermeet_Ubuntu.bgptheme
@@ -11,6 +11,7 @@ override_git_prompt_colors() {
 	GIT_PROMPT_SEPARATOR="|"              # separates each item
 
 	GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
+	GIT_PROMPT_MASTER_BRANCH="${Magenta}" # the git branch that is active in the current directory
 	GIT_PROMPT_STAGED="${Cyan}● "         # the number of staged files/directories
 	GIT_PROMPT_CONFLICTS="${BoldRed}✖ "   # the number of files in conflict
 	GIT_PROMPT_CHANGED="${Cyan}✚ "        # the number of changed files

--- a/themes/Minimal.bgptheme
+++ b/themes/Minimal.bgptheme
@@ -36,6 +36,7 @@ override_git_prompt_colors() {
   
   Time12a="\$(date +%H:%M:%S)"
   GIT_PROMPT_BRANCH="${BoldMagenta}"        # the git branch that is active in the current directory
+  GIT_PROMPT_MASTER_BRANCH="${BoldMagenta}" # the git branch that is active in the current directory
   GIT_PROMPT_PREFIX=""                 # start of the git info string
   GIT_PROMPT_SUFFIX=""                 # the end of the git info string
   GIT_PROMPT_SEPARATOR=""              # separates each item

--- a/themes/Minimal_UserHost.bgptheme
+++ b/themes/Minimal_UserHost.bgptheme
@@ -44,6 +44,7 @@ override_git_prompt_colors() {
   fi
 
   GIT_PROMPT_BRANCH="${BoldMagenta}"        # the git branch that is active in the current directory
+  GIT_PROMPT_MASTER_BRANCH="${BoldMagenta}" # the git branch that is active in the current directory
   GIT_PROMPT_PREFIX=""                 # start of the git info string
   GIT_PROMPT_SUFFIX=""                 # the end of the git info string
   GIT_PROMPT_SEPARATOR=""              # separates each item

--- a/themes/Single_line_Dark.bgptheme
+++ b/themes/Single_line_Dark.bgptheme
@@ -4,6 +4,7 @@
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Single_line_nono031"
   GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_MASTER_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
   GIT_PROMPT_STAGED="${Magenta}●"

--- a/themes/Single_line_NoExitState_Gentoo.bgptheme
+++ b/themes/Single_line_NoExitState_Gentoo.bgptheme
@@ -4,6 +4,7 @@
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Single_line_NoExitState_Gentoo"
   GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_MASTER_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
   GIT_PROMPT_STAGED="${Magenta}●"

--- a/themes/Single_line_NoExitState_openSUSE.bgptheme
+++ b/themes/Single_line_NoExitState_openSUSE.bgptheme
@@ -4,6 +4,7 @@
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Single_line_NoExitState_openSUSE"
   GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_MASTER_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
   GIT_PROMPT_STAGED="${Magenta}●"

--- a/themes/Single_line_openSUSE.bgptheme
+++ b/themes/Single_line_openSUSE.bgptheme
@@ -4,6 +4,7 @@
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Single_line_openSUSE"
   GIT_PROMPT_BRANCH="${Cyan}"
+  GIT_PROMPT_MASTER_BRANCH="${Cyan}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
   GIT_PROMPT_STAGED="${Magenta}●"


### PR DESCRIPTION
- add `$GIT_PROMPT_MASTER_BRANCH` - color for master branch
- add `$GIT_PROMPT_MASTER_BRANCHES` - branch name(s) that use $GIT_PROMPT_MASTER_BRANCH color, 'master' by default)

All other branches will continue to use $GIT_PROMPT_BRANCH

Also add $GIT_PROMPT_MASTER_BRANCH to all themes that set $GIT_PROMPT_BRANCH, using the same color as $GIT_PROMPT_BRANCH to avoid unintended changes.

Fixes https://github.com/magicmonty/bash-git-prompt/issues/311