### PR TITLE
Suppress fetch password prompt

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -432,7 +432,7 @@ function checkUpstream() {
   then
     if [[ -n $(git remote show) ]]; then
       (
-        async_run "git fetch --quiet"
+        async_run "GIT_TERMINAL_PROMPT=0 git fetch --quiet"
         disown -h
       )
     fi


### PR DESCRIPTION
When GIT_PROMPT_FETCH_REMOTE_STATUS is nonzero, suppresses useless password prompts in the terminal created by the remote status failing to be updated. Does not suppress pop-up password prompts outside the terminal
Addresses magicmonty/bash-git-prompt#354