### PR TITLE
return right away so a success looks like "1" instead of "1 0"

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -303,9 +303,9 @@ function setLastCommandState() {
 function we_are_on_repo() {
   if [[ -e "$(git rev-parse --git-dir 2> /dev/null)" ]]; then
     echo 1
-    return
+  else
+    echo 0
   fi
-  echo 0
 }
 
 function update_old_git_prompt() {

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -303,6 +303,7 @@ function setLastCommandState() {
 function we_are_on_repo() {
   if [[ -e "$(git rev-parse --git-dir 2> /dev/null)" ]]; then
     echo 1
+    return
   fi
   echo 0
 }


### PR DESCRIPTION
I use PROMPT_COMMAND for a custom prompt of my own and this code clobbers my prompt.  In my efforts to isolate the parts I want I ran across this issue which smells like a bug.

