### PR TITLE
Adds .gitattributes to keep unix lines endings in .sh files; closes #345

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Unix lines endings in bash script files
+*.sh text eol=lf
+themes/* text eol=lf


### PR DESCRIPTION
When git cloning on linux with `core.autocrlf = true` everything now works as expected.

See #345 