### PR TITLE
Fixed "red dot" and "number of files added" fonts overlaping

### DIFF
--- a/themes/Custom.bgptemplate
+++ b/themes/Custom.bgptemplate
@@ -15,7 +15,7 @@ override_git_prompt_colors() {
 
   # GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
   # GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}" # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
-  # GIT_PROMPT_STAGED="${Red}●"           # the number of staged files/directories
+  # GIT_PROMPT_STAGED="${Red}● "           # the number of staged files/directories
   # GIT_PROMPT_CONFLICTS="${Red}✖ "       # the number of files in conflict
   # GIT_PROMPT_CHANGED="${Blue}✚ "        # the number of changed files
 

--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -43,7 +43,7 @@ define_undefined_git_prompt_colors() {
 
   if [ -z ${GIT_PROMPT_BRANCH+x} ]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
   if [ -z ${GIT_PROMPT_MASTER_BRANCH+x} ]; then GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"; fi  # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
-  if [ -z ${GIT_PROMPT_STAGED+x} ]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [ -z ${GIT_PROMPT_STAGED+x} ]; then GIT_PROMPT_STAGED="${Red}● "; fi           # the number of staged files/directories
   if [ -z ${GIT_PROMPT_CONFLICTS+x} ]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
   if [ -z ${GIT_PROMPT_CHANGED+x} ]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
 

--- a/themes/Evermeet.bgptheme
+++ b/themes/Evermeet.bgptheme
@@ -10,7 +10,7 @@ override_git_prompt_colors() {
 
 	GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
 	GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}" # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
-	GIT_PROMPT_STAGED="${Cyan}●"          # the number of staged files/directories
+	GIT_PROMPT_STAGED="${Cyan}● "          # the number of staged files/directories
 	GIT_PROMPT_CONFLICTS="${BoldRed}✖"    # the number of files in conflict
 	GIT_PROMPT_CHANGED="${Cyan}✚"         # the number of changed files
 

--- a/themes/Evermeet_Lowres.bgptheme
+++ b/themes/Evermeet_Lowres.bgptheme
@@ -12,7 +12,7 @@ override_git_prompt_colors() {
 
 	GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
 	GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}" # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
-	GIT_PROMPT_STAGED="${Cyan}●"          # the number of staged files/directories
+	GIT_PROMPT_STAGED="${Cyan}● "          # the number of staged files/directories
 	GIT_PROMPT_CONFLICTS="${BoldRed}✖ "   # the number of files in conflict
 	GIT_PROMPT_CHANGED="${Cyan}✚ "        # the number of changed files
 

--- a/themes/Minimal.bgptheme
+++ b/themes/Minimal.bgptheme
@@ -40,7 +40,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_PREFIX=""                 # start of the git info string
   GIT_PROMPT_SUFFIX=""                 # the end of the git info string
   GIT_PROMPT_SEPARATOR=""              # separates each item
-  GIT_PROMPT_STAGED=" ${Green}●"           # the number of staged files/directories
+  GIT_PROMPT_STAGED=" ${Green}● "           # the number of staged files/directories
   GIT_PROMPT_CONFLICTS=" ${BoldRed}✖"       # the number of files in conflict
   GIT_PROMPT_CHANGED=" ${BoldBlue}✚"        # the number of changed files
 

--- a/themes/Minimal_UserHost.bgptheme
+++ b/themes/Minimal_UserHost.bgptheme
@@ -48,7 +48,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_PREFIX=""                 # start of the git info string
   GIT_PROMPT_SUFFIX=""                 # the end of the git info string
   GIT_PROMPT_SEPARATOR=""              # separates each item
-  GIT_PROMPT_STAGED=" ${Green}●"           # the number of staged files/directories
+  GIT_PROMPT_STAGED=" ${Green}● "           # the number of staged files/directories
   GIT_PROMPT_CONFLICTS=" ${BoldRed}✖"       # the number of files in conflict
   GIT_PROMPT_CHANGED=" ${BoldBlue}✚"        # the number of changed files
 

--- a/themes/Single_line_Dark.bgptheme
+++ b/themes/Single_line_Dark.bgptheme
@@ -7,7 +7,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${BoldGreen}\h:${BoldBlue}\w${ResetColor}"
   GIT_PROMPT_START_ROOT="_LAST_COMMAND_INDICATOR_ ${BoldRed}\h:${BoldBlue}\w${ResetColor}"

--- a/themes/Single_line_NoExitState_Gentoo.bgptheme
+++ b/themes/Single_line_NoExitState_Gentoo.bgptheme
@@ -7,7 +7,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="${BoldGreen}\u@\h ${BrightBlue}\w${ResetColor}"
   GIT_PROMPT_START_ROOT="${BoldRed}\h ${BrightBlue}\w${ResetColor}"

--- a/themes/Single_line_NoExitState_openSUSE.bgptheme
+++ b/themes/Single_line_NoExitState_openSUSE.bgptheme
@@ -7,7 +7,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="\u@\h:\w"
   GIT_PROMPT_START_ROOT="${BoldRed}\h:\w"

--- a/themes/Single_line_openSUSE.bgptheme
+++ b/themes/Single_line_openSUSE.bgptheme
@@ -7,7 +7,7 @@ override_git_prompt_colors() {
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
   GIT_PROMPT_UNTRACKED=" ${Cyan}…${ResetColor}"
   GIT_PROMPT_CHANGED="${Yellow}✚ "
-  GIT_PROMPT_STAGED="${Magenta}●"
+  GIT_PROMPT_STAGED="${Magenta}● "
 
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${ResetColor}\u@\h:\w"
   GIT_PROMPT_START_ROOT="_LAST_COMMAND_INDICATOR_ ${BoldRed}\h:\w"

--- a/themes/Solarized.bgptheme
+++ b/themes/Solarized.bgptheme
@@ -3,7 +3,7 @@
 
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Solarized"
-  GIT_PROMPT_STAGED="${Yellow}●"
+  GIT_PROMPT_STAGED="${Yellow}● "
   GIT_PROMPT_STASHED="${BoldMagenta}⚑ "
   GIT_PROMPT_CLEAN="${Green}✔"
   GIT_PROMPT_END_USER=" \n${BoldBlue}${Time12a}${ResetColor} $ "

--- a/themes/Solarized_NoExitState.bgptheme
+++ b/themes/Solarized_NoExitState.bgptheme
@@ -3,7 +3,7 @@
 
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Solarized NoExitState"
-  GIT_PROMPT_STAGED="${Yellow}●"
+  GIT_PROMPT_STAGED="${Yellow}● "
   GIT_PROMPT_STASHED="${BoldMagenta}⚑ "
   GIT_PROMPT_CLEAN="${Green}✔"
   GIT_PROMPT_COMMAND_FAIL="${Red}✘"


### PR DESCRIPTION
GIT_PROMPT_STAGED "$Red●" updated to GIT_PROMPT_STAGED "$Red● " in 12 theme files.