### PR TITLE
support new lines in original $PROMPT_COMMAND

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -656,6 +656,8 @@ function gp_install_prompt {
   if [ -z "$PROMPT_COMMAND" ]; then
     PROMPT_COMMAND=setGitPrompt
   else
+    PROMPT_COMMAND="${PROMPT_COMMAND//$'\n'/;}" # convert all new lines to semi-colons
+    PROMPT_COMMAND=${PROMPT_COMMAND#\;}; # remove leading semi-colon
     PROMPT_COMMAND=${PROMPT_COMMAND%% }; # remove trailing spaces
     PROMPT_COMMAND=${PROMPT_COMMAND%\;}; # remove trailing semi-colon
 


### PR DESCRIPTION
This fixes an obscure error that occurs when the original $PROMPT_COMMAND contains new lines

For example if original $PROMPT_COMMAND is:
```
__bp_trap_string="$(trap -p DEBUG)"
trap DEBUG
__bp_install
```
this then results to the prompt var being set to:
```
setLastCommandState; __bp_trap_string="$(trap -p DEBUG)" trap DEBUG __bp_install ;setGitPrompt
```

which then blows up during `eval` with obscure:
```
bash: PROMPT_COMMAND: line 4: syntax error near unexpected token `;'
bash: PROMPT_COMMAND: line 4: `;setGitPrompt'
```