### PR TITLE
Homebrew installation instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The symbols are as follows:
 ```sh
 if [ -f "$(brew --prefix)/opt/bash-git-prompt/share/gitprompt.sh" ]; then
   __GIT_PROMPT_DIR=$(brew --prefix)/opt/bash-git-prompt/share
+  GIT_PROMPT_ONLY_IN_REPO=1
   source "$(brew --prefix)/opt/bash-git-prompt/share/gitprompt.sh"
 fi
 ```


### PR DESCRIPTION
Added GIT_PROMPT_ONLY_IN_REPO=1 to the Homebrew installation instructions. I'm not sure why this wasn't already in here when the other installation instructions have it. It's annoying to always have Git Prompt active when you're not inside a repo.