### PR TITLE
Changed `cd` to `command cd` to force use of bash builtin cd command

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set echo
 
 function async_run() {
   {
@@ -12,11 +13,11 @@ function git_prompt_dir() {
   if [ -z "$__GIT_PROMPT_DIR" ]; then
     local SOURCE="${BASH_SOURCE[0]}"
     while [ -h "$SOURCE" ]; do
-      local DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+      local DIR="$( command cd -P "$( dirname "$SOURCE" )" && pwd )"
       SOURCE="$(readlink "$SOURCE")"
       [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
     done
-    __GIT_PROMPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    __GIT_PROMPT_DIR="$( command cd -P "$( dirname "$SOURCE" )" && pwd )"
   fi
 }
 


### PR DESCRIPTION
If user has aliased `cd` command gitprompt.sh can break. This forces bash to use the builtin version of cd.
