### PR TITLE
remove "set echo" added by the "command cd" fix

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set echo
 
 function async_run() {
   {


### PR DESCRIPTION
In commit 8ed0d31e8eb5ccf726edd0d7aaaae53c597a6365, which was only supposed to change "cd" to "command cd", this "set echo" line was also added. This command stomps on the shell's argument list, which (through a complicated chain of events) causes logins under lightdm on Linux to fail.