### PR TITLE
Let bash-git-prompt run under `set -u`

### DIFF
--- a/prompt-colors.sh
+++ b/prompt-colors.sh
@@ -60,7 +60,7 @@ define_color_names() {
   # def_color NAME ATTRCODE COLORCODE
   _def_color() {
     local def="$1=\"\`_term_color $2 $3\`\""
-    if [[ -n "$debug$verbose" ]]; then
+    if [[ ! -z "${debug+x}" ]] || [[ ! -z "${verbose+x}" ]]; then
       echo 1>&2 "+ $def"
     fi
     eval "$def"
@@ -77,6 +77,6 @@ define_color_names() {
 }
 
 # do the color definitions only once
-if [[ ${#ColorNames[*]} = 0 || -z "$IntenseBlack" || -z "$ResetColor" ]]; then
+if [[ -z "${ColorNames+x}" || -z "${IntenseBlack+x}" || -z "${ResetColor+x}" || ${#ColorNames[*]} = 0 ]]; then
   define_color_names
 fi

--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -107,7 +107,7 @@ reload_git_prompt_colors() {
   fi
 }
 
-if [[ "${GIT_PROMPT_THEME}" == "Default" && "${GIT_PROMPT_THEME_NAME}" != "Default" ]]; then
+if [[ "${GIT_PROMPT_THEME}" == "Default" ]] && [[ -z "${GIT_PROMPT_THEME_NAME+x}" || "${GIT_PROMPT_THEME_NAME}" != "Default" ]]; then
   define_helpers
   define_undefined_git_prompt_colors
 fi


### PR DESCRIPTION
`bash-git-prompt` fails to run when `set -u` is enabled in the shell, and fails with multiple cases of `-bash: <VAR>: unbound variable` as mentioned in issue [389](https://github.com/magicmonty/bash-git-prompt/issues/389). This commit makes it s.t. `bash-git-prompt` runs without error when run under `set -u`.