### PR TITLE
Allow empty GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING variable

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -444,7 +444,7 @@ function replaceSymbols() {
   # Disable globbing, so a * could be used as symbol here
   set -f
 
-  if [[ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING} ]]; then
+  if [[ ! -v GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING ]]; then
     GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING=L
   fi
 


### PR DESCRIPTION
This change allows the user to avoid any signs for missing remote tracking by allowing an empty variable (GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="").