### PR TITLE
add user/repo before branch (based on remote.origin.url)

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -210,6 +210,19 @@ gp_format_exit_status() {
   fi
 }
 
+# gp_format_username_repo
+#
+# returns "user/repo" from remote.origin.url git variable
+#
+# supports urls:
+# https://user@bitbucket.org/user/repo.git
+# https://github.com/user/repo.git
+# git@github.com:user/repo.git
+#
+gp_format_username_repo() {
+    echo "$(git config --get remote.origin.url | sed 's|^.*//||; s/.*@//; s/[^:/]\+[:/]//; s/.git$//')"
+}
+
 function git_prompt_config() {
   #Checking if root to change output
   _isroot=false
@@ -530,19 +543,15 @@ function updatePrompt() {
   local NEW_PROMPT="$EMPTY_PROMPT"
   if [[ -n "$git_status_fields" ]]; then
 
-    # supports urls:
-    # https://user@bitbucket.org/user/repo.git
-    # https://github.com/user/repo.git
-    # git@github.com:user/repo.git
-    # gives "user/repo"
-    local URL_SHORT="$(git config --get remote.origin.url | sed 's|^.*//||; s/.*@//; s/[^:/]\+[:/]//; s/.git$//'):"
+    local USERNAME_REPO=$(gp_format_username_repo)
+    local GIT_PROMPT_PREFIX_FINAL="${GIT_PROMPT_PREFIX//_USERNAME_REPO_/${USERNAME_REPO}${ResetColor}}"
 
     case "$GIT_BRANCH" in
       $GIT_PROMPT_MASTER_BRANCHES)
-        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_MASTER_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX_FINAL}${GIT_PROMPT_MASTER_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
         ;;
       *)
-        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX_FINAL}${GIT_PROMPT_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
         ;;
     esac
     local STATUS=""

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -530,12 +530,19 @@ function updatePrompt() {
   local NEW_PROMPT="$EMPTY_PROMPT"
   if [[ -n "$git_status_fields" ]]; then
 
+    # supports urls:
+    # https://user@bitbucket.org/user/repo.git
+    # https://github.com/user/repo.git
+    # git@github.com:user/repo.git
+    # gives "user/repo"
+    local URL_SHORT="$(git config --get remote.origin.url | sed 's|^.*//||; s/.*@//; s/[^:/]\+[:/]//; s/.git$//'):"
+
     case "$GIT_BRANCH" in
       $GIT_PROMPT_MASTER_BRANCHES)
-        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_MASTER_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_MASTER_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
         ;;
       *)
-        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
+        local STATUS_PREFIX="${PROMPT_LEADING_SPACE}${GIT_PROMPT_PREFIX}${GIT_PROMPT_BRANCH}${URL_SHORT}\${GIT_BRANCH}${ResetColor}${GIT_FORMATTED_UPSTREAM}"
         ;;
     esac
     local STATUS=""

--- a/themes/Single_line_username_repo.bgptheme
+++ b/themes/Single_line_username_repo.bgptheme
@@ -1,0 +1,12 @@
+# This is an alternative approach. Single line in git repo.
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Single_line_username_repo"
+
+  GIT_PROMPT_PREFIX="[ ${Blue}_USERNAME_REPO_ | "
+  GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${BoldYellow}${PathShort}${ResetColor}"
+  GIT_PROMPT_END_USER="${ResetColor} $ "
+  GIT_PROMPT_END_ROOT="${BoldRed} # "
+}
+
+reload_git_prompt_colors "Single_line_username_repo"
+


### PR DESCRIPTION
This is an excellent tool! Thank you, Martin.

I work in parallel with the original repo and its fork on github, and therefore often it's hard to tell which of the two I'm inside off, especially since both have a 'master'. So I found it very helpful to also display the user/repo information together with the branch.

This PR adds user/repo to [branch] giving us [user/repo:branch]

It supports 3 url types: `git config --get remote.origin.url`
- https://user@bitbucket.org/user/repo.git
- https://github.com/user/repo.git
- git@github.com:user/repo.git

I'm sure that it needs to be made configurable and perhaps custom color support added, but this is a start.

Thank you!