### PR TITLE
Fix directory permissions.

### DIFF
--- a/bash-git-prompt.spec
+++ b/bash-git-prompt.spec
@@ -27,12 +27,12 @@ install. It will disable the prompt accordingly after uninstall.
 # These comments are here to avoid rpm lint issue
 
 %install
-install -d 755 %{buildroot}%{_datadir}/%{name}
+install -dm 755 %{buildroot}%{_datadir}/%{name}
 install -pm 755 *.sh %{buildroot}%{_datadir}/%{name}
 #install -pm 755 *.py %{buildroot}%{_datadir}/%{name}
 install -pm 755 *.fish %{buildroot}%{_datadir}/%{name}
 install -pm 644 README.md %{buildroot}%{_datadir}/%{name}
-install -d 755 %{buildroot}%{_datadir}/%{name}/themes
+install -dm 755 %{buildroot}%{_datadir}/%{name}/themes
 install -pm 644 themes/*.bgptheme %{buildroot}%{_datadir}/%{name}/themes
 install -pm 644 themes/*.bgptemplate %{buildroot}%{_datadir}/%{name}/themes
 


### PR DESCRIPTION
`install -d` does not take a set of access settings as first numerical argument. At least on MacOS (BSD), but according to [the manpage](https://linux.die.net/man/1/install) also on Linux, an extra directory with the name **`755`** was created. Although `755` is the default value for `install -d`, just for symmetry option `-m 755` is added.