### PR TITLE
Allow empty GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING variable

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -448,7 +448,7 @@ function replaceSymbols() {
   # Disable globbing, so a * could be used as symbol here
   set -f
 
-  if [[ ! -v GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING ]]; then
+  if [ -z ${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING+x} ]; then
     GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING=L
   fi
 


### PR DESCRIPTION
#400 breaks on my machine. If we want to interpret empty string as a set variable we can use the same construct as in Default.bgptheme.



