### PR TITLE
Update old gitstatus to support remote username

### DIFF
--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -19,6 +19,19 @@ if [ -z "${__GIT_PROMPT_DIR}" ]; then
   __GIT_PROMPT_DIR="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
 fi
 
+if [[ "${__GIT_PROMPT_WITH_USERNAME_AND_REPO}" == "1" ]]; then
+  # returns "user/repo" from remote.origin.url git variable
+  #
+  # supports urls:
+  # https://user@bitbucket.org/user/repo.git
+  # https://github.com/user/repo.git
+  # git@github.com:user/repo.git
+  #
+  remote_url=$(git config --get remote.origin.url | sed 's|^.*//||; s/.*@//; s/[^:/]\+[:/]//; s/.git$//')
+else
+  remote_url='.'
+fi
+
 gitsym=$( git symbolic-ref HEAD 2>/dev/null )
 
 #If exit status OK, we have a branch
@@ -99,6 +112,7 @@ else
     fi
   else
     remote='_NO_REMOTE_TRACKING_'
+    remote_url='.'
     unset upstream
   fi
 fi
@@ -111,9 +125,10 @@ if [[ -z "$upstream" ]] ; then
   upstream='^'
 fi
 
-printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
+printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
   "$branch" \
   "$remote" \
+  "$remote_url" \
   "$upstream" \
   $num_staged \
   $num_conflicts \


### PR DESCRIPTION
The new feature with remote username changed the output of gitstatus.sh users running older git (pre 1.7.10) need to use the gitstatus_pre1.7.10.sh instead.

I updated it to hopefully work the same way.

Tested on my Centos 6 installation.

Maybe @stas00 can take a look at this?