### PR TITLE
Strip seconds from time, new color combo, no bold colors

### DIFF
--- a/themes/Minimal_Time.bgptheme
+++ b/themes/Minimal_Time.bgptheme
@@ -1,0 +1,64 @@
+##############################################################################
+# Changes the prompt to a Debian-style one that truncates pwd to a max length
+# depending on the terminal column width. Also uses the prompt_callback
+# function of bash-git-prompt to set the window title to almost the same
+# Debian-style. This version has been tweaked for Ubuntu standard terminal
+# fonts.
+#
+# The prompt will use a Debian-style on the form
+#
+# relative-path-from-git-toplevel-dir bash-git-prompt-info <exit status>
+# HH:MM ▶
+#
+# The window title will have the form
+# relative-path-from-git-toplevel-dir
+#
+# Example usage:
+# if [ -f ~/.bash-git-prompt/gitprompt.sh ]; then
+#   GIT_PROMPT_THEME=Minimal_Time
+#   source ~/.bash-git-prompt/gitprompt.sh
+# fi
+#
+# [https://github.com/modib]
+##############################################################################
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="Minimal_Time"
+
+  #Overrides the prompt_callback function used by bash-git-prompt
+  function prompt_callback {
+    GIT_CONTAINER_FOLDER_FULLPATH=$(git rev-parse --show-toplevel 2> /dev/null)
+    GIT_CONTAINER_FOLDER=$(basename $GIT_CONTAINER_FOLDER_FULLPATH 2> /dev/null)
+    CURRENT_FULLPATH=$(pwd)
+    local PS1=$GIT_CONTAINER_FOLDER${CURRENT_FULLPATH#$GIT_CONTAINER_FOLDER_FULLPATH}
+    gp_set_window_title "$PS1"
+    echo "${Cyan}${PS1}${ResetColor}"
+  }
+
+  Time12a="\$(date +%H:%M)"
+  GIT_PROMPT_BRANCH="${Magenta}"        # the git branch that is active in the current directory
+  GIT_PROMPT_MASTER_BRANCH="${Yellow}" # used if the git branch that is active in the current directory is $GIT_PROMPT_MASTER_BRANCHES
+
+  GIT_PROMPT_PREFIX="["
+  GIT_PROMPT_SUFFIX=" ]"
+  GIT_PROMPT_SEPARATOR=" |"              # separates each item
+  GIT_PROMPT_STAGED=" ${Green}●"           # the number of staged files/directories
+  GIT_PROMPT_CONFLICTS=" ${Red}✖"       # the number of files in conflict
+  GIT_PROMPT_CHANGED=" ${Blue}✚"        # the number of changed files
+
+  # GIT_PROMPT_REMOTE=" "                 # the remote branch name (if any) and the symbols for ahead and behind
+  GIT_PROMPT_UNTRACKED=" ${Cyan}…"       # the number of untracked files/dirs
+  GIT_PROMPT_STASHED=" ${Cyan}⚑"    # the number of stashed files/dir
+  GIT_PROMPT_CLEAN=" ${Green}✔"      # a colored flag indicating a "clean" repo
+  GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="✭"
+
+  local gp_end="_LAST_COMMAND_INDICATOR_\n${White}${Time12a}${ResetColor}"
+
+  GIT_PROMPT_START_USER=""
+  GIT_PROMPT_END_USER="${gp_end} ▶ "
+  GIT_PROMPT_END_ROOT="${gp_end} /!!!\ "
+
+  GIT_PROMPT_COMMAND_OK="${Green} ✔ "    # indicator if the last command returned with an exit code of 0
+  GIT_PROMPT_COMMAND_FAIL="${Red} ✘-_LAST_COMMAND_STATE_"    # indicator if the last command returned with an exit code of other than 0
+}
+
+reload_git_prompt_colors "Minimal_Time"


### PR DESCRIPTION
Derived from Minimal Theme, Minimal_Time strips the seconds from time, removes bold colors and uses a different color combination.
Also adds Prefix, Suffix and Separator to GIT PROMPT.