### PR TITLE
DOC: make sourcing conditional in README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt -
 
 Add to the `~/.bashrc`:
 ```
-GIT_PROMPT_ONLY_IN_REPO=1
-source ~/.bash-git-prompt/gitprompt.sh
+if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
+    GIT_PROMPT_ONLY_IN_REPO=1
+    source $HOME/.bash-git-prompt/gitprompt.sh
+fi
 ```
 
 ### install for the fish shell


### PR DESCRIPTION
This addition can be useful for the case when the `~/.bashrc` file with the configuration for using bash-git-prompt was copied over to a machine where `~/.bash-git-prompt` directory is not available, so it does not throw errors immediately on loading.