### PR TITLE
fixes a trailing space in upstream when remote changes available

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -182,11 +182,13 @@ if [[ -z "${upstream:+x}" ]] ; then
   upstream='^'
 fi
 
+UPSTREAM_TRIMMED=`echo $upstream |xargs`
+
 printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
   "${branch}${state}" \
   "${remote}" \
   "${remote_url}" \
-  "${upstream}" \
+  "${UPSTREAM_TRIMMED}" \
   "${num_staged}" \
   "${num_conflicts}" \
   "${num_changed}" \


### PR DESCRIPTION
Explanation:

For some reason there's a trailing space, when there are changes available on the remote:

`master {upstream/master } ↓·9|✔]$`

After doing a `git pull`, the prompt is fine again:

`master {upstream/master}|✔]$`

This change trims the upstream var in gitstatus.sh

closes #452 