### PR TITLE
Allow to coexist other PROMPT_COMMAND(s) relying on last command exit status

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -303,6 +303,7 @@ function git_prompt_config() {
 
 function setLastCommandState() {
   GIT_PROMPT_LAST_COMMAND_STATE="${?}"
+  return ${GIT_PROMPT_LAST_COMMAND_STATE}
 }
 
 function we_are_on_repo() {


### PR DESCRIPTION
If any script saved in PROMPT_COMMAND wants to know last command exit status (without using GIT_PROMPT_LAST_COMMAND_STATE, but based on "$?" shell variable) after installing `bash-git-prompt` it stopped working, because "$?" variable was set to success after assigning GIT_PROMPT_LAST_COMMAND_STATE variable.

This PR fixes it.