### PR TITLE
Fix issue #338 - Fixes behaviour if `/tmp` dir does not exist

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -480,7 +480,7 @@ function createPrivateIndex {
   else
     __GIT_INDEX_FILE="${GIT_INDEX_FILE}"
   fi
-  __GIT_INDEX_PRIVATE="/tmp/git-index-private$$"
+  __GIT_INDEX_PRIVATE="${TMPDIR:-/tmp}/git-index-private$$"
   command cp "${__GIT_INDEX_FILE}" "${__GIT_INDEX_PRIVATE}" 2>/dev/null
   echo "${__GIT_INDEX_PRIVATE}"
 }

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -105,7 +105,6 @@ while IFS='' read -r line || [[ -n "${line}" ]]; do
       AA) ((num_conflicts++)); break;;
       #two character matches, first loop
       ?M) ((num_changed++)) ;;
-      ?D) ((num_changed++)) ;;
       ?\ ) ;;
       #single character matches, second loop
       U) ((num_conflicts++)) ;;


### PR DESCRIPTION
Private index was tried to create in non-existent location, no error
was ever displayed, and then unconditionally GIT_INDEX_FILE variable
was set pointing to non-existent path. Git used this location and
reported many changed files.

Additionally in case of non-existent index file most of
files were marked with `D` in second loop pass of `gitstatus.sh`
which was wrongly identified as 'Stashed'.

It is common on Android devices - there is no /tmp directory
Termux creates one and sets `TMPDIR` variable, which is commonly
honoured by most of unix utilities.