### PR TITLE
Add new theme BlackOrWhite

### DIFF
--- a/themes/BlackOrWhite.bgptheme
+++ b/themes/BlackOrWhite.bgptheme
@@ -1,0 +1,129 @@
+######################################################################################
+# This theme for gitprompt.sh is created for the dark and light color schemes as well.
+# Base colors of the theme can be black or white, it depends on which color needed.
+# The user, hostname, time and current path text are using the terminal text color.
+# Git branch state part is using similar colors like git (red, green).
+# Also configurable to display user@hostname/time, last command state and an icon
+# before the branch name.
+# Powerline fonts are needed to display branch icon.
+#
+# By default the prompt base color is black. You can use white color with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
+#
+# By default the prompt display the user and hostname, but you can choose to
+# display time instead with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER=1
+#
+# By default the last command state is disabled. You can switch on with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
+#
+# By default to display the branch icon is disabled. You can switch on with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON=1
+#
+# Example usage:
+# if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
+#   GIT_PROMPT_THEME=BlackOrWhite
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER=1
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON=1
+#   source $HOME/.bash-git-prompt/gitprompt.sh
+# fi
+#
+# Samples:
+#
+# Display user and hostname
+# ┌─(user@hostname)──(~)
+# └─•
+#
+# Display time instead of user and hostname
+# ┌─(10:58:58)──(~)
+# └─•
+#
+# Display root user prompt
+# ┌─(11:08:06)──(/home/root)
+# └─!
+#
+# Display git branch without or with the branch icon
+# ┌─(10:59:31)──(~/.bash-git-prompt)──(master|✔)
+# └─•
+#
+# ┌─(10:59:31)──(~/.bash-git-prompt)──( master|✔)
+# └─•
+#
+# Display git branch with upstream
+# ┌─(user@hostname)──(~/.bash-git-prompt)──( master {origin/master}|…1)
+# └─•
+#
+# Display last command state
+# ┌─(user@hostname)──(~/.bash-git-prompt)──(>_ ✔)──( master|…1)
+# └─•
+#
+######################################################################################
+override_git_prompt_colors() {
+  GIT_PROMPT_THEME_NAME="BlackOrWhite"
+
+  local PathShort="\w"
+  local PS1Color="${BoldBlack}"
+
+  case $GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR in
+    black)
+      PS1Color="${BoldBlack}"
+      ;;
+    white)
+      PS1Color="${BoldWhite}"
+      ;;
+  esac
+
+  local FirstBubbleContent="\u${PS1Color}@${ResetColor}\h"
+  local CommandStateBubbleContent=""
+  local BranchIcon=""
+
+  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER}" == "1" ]]; then
+    FirstBubbleContent="\t"
+  fi
+
+  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE}" == "1" ]]; then
+    CommandStateBubbleContent=")──(${ResetColor}>_ _LAST_COMMAND_INDICATOR_${PS1Color}"
+  fi
+
+  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON}" == "1" ]]; then
+    BranchIcon=" "
+  fi
+
+  GIT_PROMPT_LEADING_SPACE=0
+
+  GIT_PROMPT_PREFIX="${PS1Color}──(${ResetColor}${BranchIcon}"
+  GIT_PROMPT_SUFFIX="${PS1Color})${ResetColor}"
+  # GIT_PROMPT_SEPARATOR="|"
+
+  GIT_PROMPT_BRANCH="${PS1Color}"
+  GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
+  GIT_PROMPT_STAGED="${BoldGreen}•"
+  GIT_PROMPT_CONFLICTS="${BoldRed}x"
+  GIT_PROMPT_CHANGED="${BoldRed}+"
+
+  # GIT_PROMPT_REMOTE=" "
+  GIT_PROMPT_UNTRACKED="${PS1Color}…"
+  GIT_PROMPT_STASHED="${PS1Color}⚑ "
+  GIT_PROMPT_CLEAN="${BoldGreen}✔"
+
+  # GIT_PROMPT_COMMAND_OK="${Green}✔"
+  # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_"
+
+  # GIT_PROMPT_SYMBOLS_AHEAD="↑·"
+  # GIT_PROMPT_SYMBOLS_BEHIND="↓·"
+  # GIT_PROMPT_SYMBOLS_PREHASH=":"
+  # GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"
+
+  GIT_PROMPT_VIRTUALENV="[${PS1Color}_VIRTUALENV_${ResetColor}] "
+
+  GIT_PROMPT_UPSTREAM=" {${PS1Color}_UPSTREAM_${ResetColor}}"
+
+  GIT_PROMPT_START_USER="\n${PS1Color}┌─(${ResetColor}${FirstBubbleContent}${PS1Color})──(${ResetColor}${PathShort}${PS1Color}${CommandStateBubbleContent})${ResetColor}"
+  GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
+  GIT_PROMPT_END_USER="\n${PS1Color}└─•${ResetColor} "
+  GIT_PROMPT_END_ROOT="\n${PS1Color}└─!${ResetColor} "
+}
+
+reload_git_prompt_colors "BlackOrWhite"

--- a/themes/BlackOrWhite.bgptheme
+++ b/themes/BlackOrWhite.bgptheme
@@ -3,9 +3,9 @@
 # Base colors of the theme can be black or white, it depends on which color needed.
 # The user, hostname, time and current path text are using the terminal text color.
 # Git branch state part is using similar colors like git (red, green).
-# Also configurable to display user@hostname/time, last command state and an icon
-# before the branch name.
-# Powerline fonts are needed to display branch icon.
+# Also configurable to display user@hostname/time, last command state and additional
+# icons before content.
+# Powerline and/or Nerd fonts are needed to display icons.
 #
 # By default the prompt base color is black. You can use white color with
 # GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
@@ -17,8 +17,11 @@
 # By default the last command state is disabled. You can switch on with
 # GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
 #
-# By default to display the branch icon is disabled. You can switch on with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON=1
+# By default to display the powerline icon is disabled. You can switch on with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON=1
+#
+# By default to display the nerd fonts icons are disabled. You can switch on with
+# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS=1
 #
 # Example usage:
 # if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
@@ -26,7 +29,8 @@
 #   GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
 #   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER=1
 #   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
-#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON=1
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON=1
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS=1
 #   source $HOME/.bash-git-prompt/gitprompt.sh
 # fi
 #
@@ -44,7 +48,7 @@
 # ┌─(11:08:06)──(/home/root)
 # └─!
 #
-# Display git branch without or with the branch icon
+# Display git branch without or with the powerline icon
 # ┌─(10:59:31)──(~/.bash-git-prompt)──(master|✔)
 # └─•
 #
@@ -57,6 +61,13 @@
 #
 # Display last command state
 # ┌─(user@hostname)──(~/.bash-git-prompt)──(>_ ✔)──( master|…1)
+# └─•
+#
+# Display nerd fonts icons
+# ┌─( user)──( hostname)──( ~/.bash-git-prompt)──(  )──( master| 2)
+# └─•
+#
+# ┌─( 11:45:19)──( ~/.bash-git-prompt)──(  )──( master| 2)
 # └─•
 #
 ######################################################################################
@@ -77,18 +88,62 @@ override_git_prompt_colors() {
 
   local FirstBubbleContent="\u${PS1Color}@${ResetColor}\h"
   local CommandStateBubbleContent=""
+  local PathBubbleContent=""
+
+  local UserIcon=""
+  local ComputerIcon=""
+  local ClockIcon=""
+  local CommandPromptIcon=">_ "
+  local FolderIcon=""
   local BranchIcon=""
+  local StagedIcon="•"
+  local ConflictsIcon="x"
+  local ChangedIcon="+"
+  local RemoteIcon=" "
+  local UntrackedIcon="…"
+  local StashedIcon="⚑ "
+  local CleanIcon="✔"
+  local CommandOkIcon="✔"
+  local CommandFailIcon="✘"
+  local AheadIcon="↑·"
+  local BehindIcon="↓·"
+  local PrehashIcon=":"
+  local NoRemoteTrackingIcon="L"
+
+  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS}" == "1" ]]; then
+    UserIcon=" "
+    ComputerIcon=" "
+    ClockIcon=" "
+    CommandPromptIcon=" "
+    FolderIcon=" "
+    BranchIcon=" "
+    StagedIcon=" "
+    ConflictsIcon="ﴜ "
+    ChangedIcon=" "
+    UntrackedIcon=" "
+    StashedIcon=" "
+    CleanIcon=" "
+    CommandOkIcon=" "
+    CommandFailIcon=" "
+    AheadIcon=" "
+    BehindIcon=" "
+    NoRemoteTrackingIcon=" "
+  fi
+
+  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON}" == "1" ]]; then
+    BranchIcon=" "
+  fi
 
   if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER}" == "1" ]]; then
-    FirstBubbleContent="\t"
+    FirstBubbleContent="${ClockIcon}\t"
+  elif [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS}" == "1" ]]; then
+    FirstBubbleContent="${UserIcon}\u${PS1Color})──(${ResetColor}${ComputerIcon}\h"
   fi
+
+  PathBubbleContent="${FolderIcon}${PathShort}"
 
   if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE}" == "1" ]]; then
-    CommandStateBubbleContent=")──(${ResetColor}>_ _LAST_COMMAND_INDICATOR_${PS1Color}"
-  fi
-
-  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_BRANCH_ICON}" == "1" ]]; then
-    BranchIcon=" "
+    CommandStateBubbleContent=")──(${ResetColor}${CommandPromptIcon}_LAST_COMMAND_INDICATOR_${PS1Color}"
   fi
 
   GIT_PROMPT_LEADING_SPACE=0
@@ -99,28 +154,28 @@ override_git_prompt_colors() {
 
   GIT_PROMPT_BRANCH="${PS1Color}"
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
-  GIT_PROMPT_STAGED="${BoldGreen}•"
-  GIT_PROMPT_CONFLICTS="${BoldRed}x"
-  GIT_PROMPT_CHANGED="${BoldRed}+"
+  GIT_PROMPT_STAGED="${BoldGreen}${StagedIcon}"
+  GIT_PROMPT_CONFLICTS="${BoldRed}${ConflictsIcon}"
+  GIT_PROMPT_CHANGED="${BoldRed}${ChangedIcon}"
 
-  # GIT_PROMPT_REMOTE=" "
-  GIT_PROMPT_UNTRACKED="${PS1Color}…"
-  GIT_PROMPT_STASHED="${PS1Color}⚑ "
-  GIT_PROMPT_CLEAN="${BoldGreen}✔"
+  GIT_PROMPT_REMOTE="${RemoteIcon}"
+  GIT_PROMPT_UNTRACKED="${PS1Color}${UntrackedIcon}"
+  GIT_PROMPT_STASHED="${PS1Color}${StashedIcon}"
+  GIT_PROMPT_CLEAN="${BoldGreen}${CleanIcon}"
 
-  # GIT_PROMPT_COMMAND_OK="${Green}✔"
-  # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_"
+  GIT_PROMPT_COMMAND_OK="${Green}${CommandOkIcon}"
+  GIT_PROMPT_COMMAND_FAIL="${Red}${CommandFailIcon}-_LAST_COMMAND_STATE_"
 
-  # GIT_PROMPT_SYMBOLS_AHEAD="↑·"
-  # GIT_PROMPT_SYMBOLS_BEHIND="↓·"
-  # GIT_PROMPT_SYMBOLS_PREHASH=":"
-  # GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L"
+  GIT_PROMPT_SYMBOLS_AHEAD="${AheadIcon}"
+  GIT_PROMPT_SYMBOLS_BEHIND="${BehindIcon}"
+  GIT_PROMPT_SYMBOLS_PREHASH="${PrehashIcon}"
+  GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="${NoRemoteTrackingIcon}"
 
   GIT_PROMPT_VIRTUALENV="[${PS1Color}_VIRTUALENV_${ResetColor}] "
 
   GIT_PROMPT_UPSTREAM=" {${PS1Color}_UPSTREAM_${ResetColor}}"
 
-  GIT_PROMPT_START_USER="\n${PS1Color}┌─(${ResetColor}${FirstBubbleContent}${PS1Color})──(${ResetColor}${PathShort}${PS1Color}${CommandStateBubbleContent})${ResetColor}"
+  GIT_PROMPT_START_USER="\n${PS1Color}┌─(${ResetColor}${FirstBubbleContent}${PS1Color})──(${ResetColor}${PathBubbleContent}${PS1Color}${CommandStateBubbleContent})${ResetColor}"
   GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
   GIT_PROMPT_END_USER="\n${PS1Color}└─•${ResetColor} "
   GIT_PROMPT_END_ROOT="\n${PS1Color}└─!${ResetColor} "

--- a/themes/BlackOrWhite.bgptheme
+++ b/themes/BlackOrWhite.bgptheme
@@ -1,40 +1,87 @@
 ######################################################################################
 # This theme for gitprompt.sh is created for the dark and light color schemes as well.
 # Base colors of the theme can be black or white, it depends on which color needed.
-# The user, hostname, time and current path text are using the terminal text color.
+# The text is using the terminal text color.
 # Git branch state part is using similar colors like git (red, green).
-# Also configurable to display user@hostname/time, last command state and additional
-# icons before content.
-# Powerline and/or Nerd fonts are needed to display icons.
+# Also, configurable which part to display and where to show icons.
+# Nerd fonts are needed to display icons.
 #
-# By default the prompt base color is black. You can use white color with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
+# Settings:
+# =========
 #
-# By default the prompt display the user and hostname, but you can choose to
-# display time instead with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER=1
+# Color options:
+# --------------
+# Variable name: GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR
+# Possible values:
+#   - black (default)
+#   - white
 #
-# By default the last command state is disabled. You can switch on with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
+# Command prompt styles:
+# ----------------------
+# Variable name: GIT_PROMPT_BLACK_OR_WHITE_THEME_STYLE
+# Possible values:
+#   - bubbles                  (default)
+#   - bubbles_with_double_line
+#   - powerline
 #
-# By default to display the powerline icon is disabled. You can switch on with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON=1
+# Visible sections:
+# -----------------
+# This is a comma-separated list of the shown sections. It will show the sections
+# as you add to the list. If this variable is missing or it has no any values,
+# then it will show the path.
 #
-# By default to display the nerd fonts icons are disabled. You can switch on with
-# GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS=1
+# Variable name: GIT_PROMPT_BLACK_OR_WHITE_THEME_VISIBLE_SECTIONS
+# Possible options:
+#   - hostname
+#   - last_command_state
+#   - os                 (OS name)
+#   - os_icon            (Only the OS icon)
+#   - time
+#   - user
+#   - user_and_hostname
+#   - path               (default)
+#
+# Icons in sections:
+# -----------------
+# This is a comma-separated list of the shown icons in sections. It will show an
+# icon if originally was not there or it will replace the default icon.
+#
+# Variable name: GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_OR_REPLACE_ICONS_IN_SECTIONS
+# Possible options:
+#   - git_branch                 (add branch icon before the branch name)
+#   - git_branch_powerline       (add the powerline branch icon before the branch name)
+#   - git_status                 (replace the original icons)
+#   - hostname                   (add icon to the hostname section)
+#   - last_command_state_ok_fail (replace the original icons in the last_command_state section)
+#   - last_command_state_prompt  (replace the original icons in the last_command_state section)
+#   - os                         (add icon to the os section)
+#   - path                       (add icon to the path section)
+#   - time                       (add icon to the time section)
+#   - user                       (add icon to the user section)
+#
+# Extra space after icons:
+# ------------------------
+# Sometimes you need extra space after icons (because of the size of the icons).
+#
+# Variable name: GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_EXTRA_SPACE_AFTER_ICONS
+# Possible options:
+#   - true
+#   - false
 #
 # Example usage:
+# --------------
 # if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
 #   GIT_PROMPT_THEME=BlackOrWhite
 #   GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR=white
-#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER=1
-#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE=1
-#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON=1
-#   GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS=1
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_STYLE=bubbles
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_VISIBLE_SECTIONS=os_icon,path,last_command_state
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_OR_REPLACE_ICONS_IN_SECTIONS=path,last_command_state_prompt,last_command_state_ok_fail,git_branch_powerline,git_status
+#   GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_EXTRA_SPACE_AFTER_ICONS=true
 #   source $HOME/.bash-git-prompt/gitprompt.sh
 # fi
 #
 # Samples:
+# ========
 #
 # Display user and hostname
 # ┌─(user@hostname)──(~)
@@ -46,13 +93,13 @@
 #
 # Display root user prompt
 # ┌─(11:08:06)──(/home/root)
-# └─!
+# └─(!)─•
 #
-# Display git branch without or with the powerline icon
-# ┌─(10:59:31)──(~/.bash-git-prompt)──(master|✔)
+# Display git branch with or without the branch icon
+# ┌─(10:59:31)──(~/.bash-git-prompt)──( master|✔)
 # └─•
 #
-# ┌─(10:59:31)──(~/.bash-git-prompt)──( master|✔)
+# ┌─(10:59:31)──(~/.bash-git-prompt)──(master|✔)
 # └─•
 #
 # Display git branch with upstream
@@ -63,122 +110,351 @@
 # ┌─(user@hostname)──(~/.bash-git-prompt)──(>_ ✔)──( master|…1)
 # └─•
 #
-# Display nerd fonts icons
-# ┌─( user)──( hostname)──( ~/.bash-git-prompt)──(  )──( master| 2)
+# Display sections with icons
+# ┌─(  user)──(  hostname)──(  ~/.bash-git-prompt)──(   )──( master| 2)
 # └─•
 #
-# ┌─( 11:45:19)──( ~/.bash-git-prompt)──(  )──( master| 2)
+# ┌─(  11:45:19)──(  ~/.bash-git-prompt)──(   )──( master| 2)
+# └─•
+#
+# Display prompt in different styles
+# ╔═(  macos)══(  user)══(  hostname)══( ~)══(   )
+# ╚═>
+#
+# ╔═(  macos)══(  user)══(  hostname)══(  ~/.bash-git-prompt)══(   )
+# ╠═( master  | 1)
+# ╚═>
+#
+# ┌─      user    hostname    ~    
+# └─•
+#
+# ┌─      user    hostname    ~/.bash-git-prompt        master  | 1
 # └─•
 #
 ######################################################################################
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="BlackOrWhite"
 
-  local PathShort="\w"
-  local PS1Color="${BoldBlack}"
+  local ResetColor="\[\033[0m\]"
+  local PS1BoldBlackColor="\[\033[1;30m\]"                # Bold black no background
+  local PS1BoldWhiteColor="\[\033[1;97m\]"                # Bold white no background
+  local PS1BoldGreenColor="\[\033[1;32m\]"                # Bold green no background
+  local PS1BoldRedColor="\[\033[1;31m\]"                  # Bold red no background
+  local PS1WhiteBlackBackgroundColor="\[\033[0;97;40m\]"  # White with black background
+  local PS1GreenBlackBackgroundColor="\[\033[0;32;40m\]"  # Green with black background
+  local PS1RedBlackBackgroundColor="\[\033[0;31;40m\]"    # Red with black background
+  local PS1BlackWhiteBackgroundColor="\[\033[0;30;107m\]" # Black with white background
+  local PS1GreenWhiteBackgroundColor="\[\033[0;32;107m\]" # Green with white background
+  local PS1RedWhiteBackgroundColor="\[\033[0;31;107m\]"   # Red with white background
+
+  local PS1Color="${PS1BoldBlackColor}"
+  local PS1GreenColor="${PS1BoldGreenColor}"
+  local PS1RedColor="${PS1BoldRedColor}"
+  local PS1SartEndColor="${PS1BoldBlackColor}"
+  local PS1ResetColor="${ResetColor}"
 
   case $GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR in
-    black)
-      PS1Color="${BoldBlack}"
+    black )
+      # Default
       ;;
-    white)
-      PS1Color="${BoldWhite}"
+
+    white )
+      PS1Color="${PS1BoldWhiteColor}"
+      PS1SartEndColor="${PS1BoldWhiteColor}"
       ;;
   esac
 
-  local FirstBubbleContent="\u${PS1Color}@${ResetColor}\h"
-  local CommandStateBubbleContent=""
-  local PathBubbleContent=""
+  local PromptStartPrefix="┌─("
+  local PromptStartMiddle=")──("
+  local PromptStartSuffix=")"
+  local PromptGitPrefix="──("
+  local PromptGitSuffix=")"
+  local PromptEndUser="└─•"
+  local PromptEndRoot="└─(!)─•"
 
+  case $GIT_PROMPT_BLACK_OR_WHITE_THEME_STYLE in
+    bubbles )
+      # Default
+      ;;
+
+    bubbles_with_double_line )
+      PromptStartPrefix="╔═("
+      PromptStartMiddle=")══("
+      PromptStartSuffix=")"
+      PromptGitPrefix="\n╠═("
+      PromptGitSuffix=")"
+      PromptEndUser="╚═>"
+      PromptEndRoot="╚═(!)═>"
+      ;;
+
+    powerline )
+      PS1ResetColor=""
+
+      case $GIT_PROMPT_BLACK_OR_WHITE_THEME_PS1_COLOR in
+        black )
+          PS1Color="${PS1WhiteBlackBackgroundColor}"
+          PS1GreenColor="${PS1GreenBlackBackgroundColor}"
+          PS1RedColor="${PS1RedBlackBackgroundColor}"
+          ;;
+
+        white )
+          PS1Color="${PS1BlackWhiteBackgroundColor}"
+          PS1GreenColor="${PS1GreenWhiteBackgroundColor}"
+          PS1RedColor="${PS1RedWhiteBackgroundColor}"
+          ;;
+      esac
+
+      PromptStartPrefix="┌─${ResetColor}${PS1Color} "
+      PromptStartMiddle="  "
+      PromptStartSuffix=""
+      PromptGitPrefix=" "
+      PromptGitSuffix=" "
+      ;;
+    esac
+
+  local OsType=""
+
+  case "$(uname)" in
+    Darwin )
+      OsType="macos"
+      ;;
+
+    Linux )
+      OsType="$(cat /etc/os-release | grep ^ID= | cut -d'=' -f2)"
+      ;;
+  esac
+
+  local ExtraSpaceAfterIcon=""
+
+  if [[ "$GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_EXTRA_SPACE_AFTER_ICONS" == "true" ]]; then
+    ExtraSpaceAfterIcon=" "
+  fi
+
+  # os
+  local OsIcon=""
+  # user
   local UserIcon=""
+  # hostname
   local ComputerIcon=""
+  # time
   local ClockIcon=""
-  local CommandPromptIcon=">_ "
+  # path
   local FolderIcon=""
+  # last_command_state
+  local CommandPromptIcon=">_ "
+  local CommandOkIcon="✔"
+  local CommandFailIcon="✘"
+  # git
   local BranchIcon=""
   local StagedIcon="•"
   local ConflictsIcon="x"
   local ChangedIcon="+"
   local RemoteIcon=" "
   local UntrackedIcon="…"
-  local StashedIcon="⚑ "
+  local StashedIcon="⚑${ExtraSpaceAfterIcon}"
   local CleanIcon="✔"
-  local CommandOkIcon="✔"
-  local CommandFailIcon="✘"
   local AheadIcon="↑·"
   local BehindIcon="↓·"
   local PrehashIcon=":"
   local NoRemoteTrackingIcon="L"
 
-  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS}" == "1" ]]; then
-    UserIcon=" "
-    ComputerIcon=" "
-    ClockIcon=" "
-    CommandPromptIcon=" "
-    FolderIcon=" "
-    BranchIcon=" "
-    StagedIcon=" "
-    ConflictsIcon="ﴜ "
-    ChangedIcon=" "
-    UntrackedIcon=" "
-    StashedIcon=" "
-    CleanIcon=" "
-    CommandOkIcon=" "
-    CommandFailIcon=" "
-    AheadIcon=" "
-    BehindIcon=" "
-    NoRemoteTrackingIcon=" "
+  for IconInSection in ${GIT_PROMPT_BLACK_OR_WHITE_THEME_ADD_OR_REPLACE_ICONS_IN_SECTIONS//,/ }; do
+    case $IconInSection in
+      os )
+        case $OsType in
+          macos )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          archlinux )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          centos )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          debian )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          fedora )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          gentoo )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          linuxmint )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          opensuse )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          redhat )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+
+          ubuntu )
+            OsIcon=" ${ExtraSpaceAfterIcon}"
+            ;;
+        esac
+        ;;
+
+      user )
+        UserIcon=" ${ExtraSpaceAfterIcon}"
+        ;;
+
+      hostname )
+        ComputerIcon=" ${ExtraSpaceAfterIcon}"
+        ;;
+
+      time )
+        ClockIcon=" ${ExtraSpaceAfterIcon}"
+        ;;
+
+      path )
+        FolderIcon=" ${ExtraSpaceAfterIcon}"
+        ;;
+
+      last_command_state_prompt )
+        CommandPromptIcon=" ${ExtraSpaceAfterIcon}"
+        ;;
+
+      last_command_state_ok_fail )
+        CommandOkIcon="${ExtraSpaceAfterIcon}"
+        CommandFailIcon="${ExtraSpaceAfterIcon}"
+        ;;
+
+      git_branch_powerline )
+        BranchIcon=" "
+        ;;
+
+      git_branch )
+        BranchIcon=" "
+        ;;
+
+      git_status )
+        StagedIcon="${ExtraSpaceAfterIcon}"
+        ConflictsIcon="ﴜ${ExtraSpaceAfterIcon}"
+        ChangedIcon="${ExtraSpaceAfterIcon}"
+        UntrackedIcon="${ExtraSpaceAfterIcon}"
+        StashedIcon="${ExtraSpaceAfterIcon}"
+        CleanIcon="${ExtraSpaceAfterIcon}"
+        AheadIcon="${ExtraSpaceAfterIcon}${ExtraSpaceAfterIcon}"
+        BehindIcon="${ExtraSpaceAfterIcon}${ExtraSpaceAfterIcon}"
+        NoRemoteTrackingIcon="${ExtraSpaceAfterIcon}"
+        ;;
+    esac
+  done
+
+  local SectionAdded=0
+  local SectionAddedCounter=0
+
+  GIT_PROMPT_START_USER="\n${PS1SartEndColor}${PromptStartPrefix}${PS1ResetColor}"
+
+  for VisibleSection in ${GIT_PROMPT_BLACK_OR_WHITE_THEME_VISIBLE_SECTIONS//,/ }; do
+    if [[ $SectionAdded -eq 1 ]]; then
+      GIT_PROMPT_START_USER+="${PS1Color}${PromptStartMiddle}${PS1ResetColor}"
+      SectionAdded=0
+    fi
+
+    case $VisibleSection in
+      os )
+        GIT_PROMPT_START_USER+="${OsIcon}${OsType}"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      os_icon )
+        GIT_PROMPT_START_USER+="${OsIcon%?}"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      user )
+        GIT_PROMPT_START_USER+="${UserIcon}\u"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      hostname )
+        GIT_PROMPT_START_USER+="${ComputerIcon}\h"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      user_and_hostname )
+        GIT_PROMPT_START_USER+="\u${PS1Color}@${PS1ResetColor}\h"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      time )
+        GIT_PROMPT_START_USER+="${ClockIcon}\t"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      path )
+        GIT_PROMPT_START_USER+="${FolderIcon}\w"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+
+      last_command_state )
+        GIT_PROMPT_START_USER+="${CommandPromptIcon}_LAST_COMMAND_INDICATOR_"
+        SectionAdded=1
+        ((SectionAddedCounter++))
+        ;;
+    esac
+  done
+
+  if [[ $SectionAddedCounter -eq 0 ]]; then
+    GIT_PROMPT_START_USER+="\w"
   fi
 
-  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_POWERLINE_ICON}" == "1" ]]; then
-    BranchIcon=" "
-  fi
+  GIT_PROMPT_START_USER+="${PS1Color}${PromptStartSuffix}${PS1ResetColor}"
 
-  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_TIME_INSTEAD_OF_USER}" == "1" ]]; then
-    FirstBubbleContent="${ClockIcon}\t"
-  elif [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_NERD_FONTS_ICONS}" == "1" ]]; then
-    FirstBubbleContent="${UserIcon}\u${PS1Color})──(${ResetColor}${ComputerIcon}\h"
-  fi
-
-  PathBubbleContent="${FolderIcon}${PathShort}"
-
-  if [[ "${GIT_PROMPT_BLACK_OR_WHITE_THEME_SHOW_LAST_COMMAND_STATE}" == "1" ]]; then
-    CommandStateBubbleContent=")──(${ResetColor}${CommandPromptIcon}_LAST_COMMAND_INDICATOR_${PS1Color}"
+  if [[ "$GIT_PROMPT_BLACK_OR_WHITE_THEME_STYLE" == "powerline" ]]; then
+    GIT_PROMPT_START_USER+=" "
   fi
 
   GIT_PROMPT_LEADING_SPACE=0
 
-  GIT_PROMPT_PREFIX="${PS1Color}──(${ResetColor}${BranchIcon}"
-  GIT_PROMPT_SUFFIX="${PS1Color})${ResetColor}"
-  # GIT_PROMPT_SEPARATOR="|"
+  GIT_PROMPT_PREFIX="${PS1Color}${PromptGitPrefix}${PS1ResetColor}${BranchIcon}"
+  GIT_PROMPT_SUFFIX="${PS1Color}${PromptGitSuffix}${PS1ResetColor}"
+  GIT_PROMPT_SEPARATOR="${PS1Color}${PS1ResetColor}|"
 
   GIT_PROMPT_BRANCH="${PS1Color}"
   GIT_PROMPT_MASTER_BRANCH="${GIT_PROMPT_BRANCH}"
-  GIT_PROMPT_STAGED="${BoldGreen}${StagedIcon}"
-  GIT_PROMPT_CONFLICTS="${BoldRed}${ConflictsIcon}"
-  GIT_PROMPT_CHANGED="${BoldRed}${ChangedIcon}"
+  GIT_PROMPT_STAGED="${PS1GreenColor}${StagedIcon}"
+  GIT_PROMPT_CONFLICTS="${PS1RedColor}${ConflictsIcon}"
+  GIT_PROMPT_CHANGED="${PS1RedColor}${ChangedIcon}"
 
-  GIT_PROMPT_REMOTE="${RemoteIcon}"
+  GIT_PROMPT_REMOTE="${PS1Color}${RemoteIcon}"
   GIT_PROMPT_UNTRACKED="${PS1Color}${UntrackedIcon}"
   GIT_PROMPT_STASHED="${PS1Color}${StashedIcon}"
-  GIT_PROMPT_CLEAN="${BoldGreen}${CleanIcon}"
+  GIT_PROMPT_CLEAN="${PS1GreenColor}${CleanIcon}"
 
-  GIT_PROMPT_COMMAND_OK="${Green}${CommandOkIcon}"
-  GIT_PROMPT_COMMAND_FAIL="${Red}${CommandFailIcon}-_LAST_COMMAND_STATE_"
+  GIT_PROMPT_COMMAND_OK="${PS1GreenColor}${CommandOkIcon}"
+  GIT_PROMPT_COMMAND_FAIL="${PS1RedColor}${CommandFailIcon}-_LAST_COMMAND_STATE_"
 
-  GIT_PROMPT_SYMBOLS_AHEAD="${AheadIcon}"
-  GIT_PROMPT_SYMBOLS_BEHIND="${BehindIcon}"
+  GIT_PROMPT_SYMBOLS_AHEAD="${PS1Color}${AheadIcon}"
+  GIT_PROMPT_SYMBOLS_BEHIND="${PS1Color}${BehindIcon}"
   GIT_PROMPT_SYMBOLS_PREHASH="${PrehashIcon}"
-  GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="${NoRemoteTrackingIcon}"
+  GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="${PS1Color}${NoRemoteTrackingIcon}"
 
-  GIT_PROMPT_VIRTUALENV="[${PS1Color}_VIRTUALENV_${ResetColor}] "
+  GIT_PROMPT_VIRTUALENV="${PS1Color}${PS1ResetColor}[${PS1Color}_VIRTUALENV_${PS1ResetColor}] "
 
-  GIT_PROMPT_UPSTREAM=" {${PS1Color}_UPSTREAM_${ResetColor}}"
+  GIT_PROMPT_UPSTREAM="${PS1Color} ${PS1ResetColor}{${PS1Color}_UPSTREAM_${PS1ResetColor}}"
 
-  GIT_PROMPT_START_USER="\n${PS1Color}┌─(${ResetColor}${FirstBubbleContent}${PS1Color})──(${ResetColor}${PathBubbleContent}${PS1Color}${CommandStateBubbleContent})${ResetColor}"
   GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
-  GIT_PROMPT_END_USER="\n${PS1Color}└─•${ResetColor} "
-  GIT_PROMPT_END_ROOT="\n${PS1Color}└─!${ResetColor} "
+  GIT_PROMPT_END_USER="${ResetColor}${PS1SartEndColor}\n${PromptEndUser}${ResetColor} "
+  GIT_PROMPT_END_ROOT="${ResetColor}${PS1SartEndColor}\n${PromptEndRoot}${ResetColor} "
 }
 
 reload_git_prompt_colors "BlackOrWhite"


### PR DESCRIPTION
I'm using a modified bash prompt to show git branch in the prompt, but special git informations were missing. When I found your awesome project I decided that I would like to use it. So I created a new theme with that prompt what I'm using and I thought if I already worked on it then I would like to share with you.

![black_prompt](https://user-images.githubusercontent.com/1647831/75606828-19853580-5af1-11ea-926b-13dae895a503.png)
![white_prompt](https://user-images.githubusercontent.com/1647831/75606831-1ee28000-5af1-11ea-9aa4-55e550ae30eb.png)
![borwthemewithnerdfontsblack](https://user-images.githubusercontent.com/1647831/102077307-5c5a9480-3e09-11eb-8811-d8e509175e4c.png)
![borwthemewithnerdfontswhite](https://user-images.githubusercontent.com/1647831/102077360-73998200-3e09-11eb-9937-ddd53a9c354a.png)
![bgpbowbwdl](https://user-images.githubusercontent.com/1647831/196026385-49f02098-47f3-47ae-843e-8ccd8339f3c3.jpg)
![bgpbowp](https://user-images.githubusercontent.com/1647831/196026392-53703f84-8e6f-4d64-9bd3-f08e1db642dc.jpg)


