### PR TITLE
Use raw ASCII escapes, not bash escapes, for colors

### DIFF
--- a/prompt-colors.sh
+++ b/prompt-colors.sh
@@ -53,7 +53,7 @@ define_color_names() {
     else
       cv="${1}"
     fi
-    echo "\[\033[${cv}m\]"
+    echo "\001\033[${cv}m\002"
   }
 
   # def_color NAME ATTRCODE COLORCODE


### PR DESCRIPTION
There's two ways of expressing "non-printing characters" in bash -- the bash-specific escapes `\[` and `\]`, and the ANSI escape codes `\001` (`soh`, start-of-heading), and `\002` (`stx`, start-of-text). In fact, when bash outputs a prompt, it outputs `\001` for `\[` and `\002` for `\]` -- the brackets are syntax sugar.

But there is one practical difference between the two -- bash will _not_ translate `\[` and `\]` when they are in the output of a shell function. So if you have eg.

```
red_honk () {
  echo "${Red}HONK${ResetColor}"
}

GIT_PROMPT_START='$(red_honk)'
```

then without this PR your prompt will contain

```
\[\]HONK\[\]
```

(with the `\]HONK\[` being red, of course). 

This PR updates `prompt-colors.sh` to use the raw ASCII escapes instead of the bash ones, so that the color names can be used anywhere, including inline in a prompt and in functions. (As an added bonus, it also means they can be used outside of prompts, too.)