### PR TITLE
Replace while read loop with a readarray

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -500,7 +500,7 @@ function updatePrompt() {
   export GIT_INDEX_FILE="${GIT_INDEX_PRIVATE}"
 
   local -a git_status_fields
-  while IFS=$'\n' read -r line; do git_status_fields+=("${line}"); done < <("${__GIT_STATUS_CMD}" 2>/dev/null)
+  readarray -t git_status_fields < <("${__GIT_STATUS_CMD}" 2>/dev/null)
 
   export GIT_BRANCH=$(replaceSymbols "${git_status_fields[0]}")
   local GIT_REMOTE="$(replaceSymbols "${git_status_fields[1]}")"


### PR DESCRIPTION
My `$WORK` has a [TMOUT](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-TMOUT) policy for its shell logins, and I was noticing that when using this prompt the session was staying logged in, way past the time allowed!

I'm not sure what is going on to make bash think the `read` is still happening to make the TMOUT effect not work.  But replacing the `while read` loop with `readarray` - the latter being the preferred way, I've found, to read lines from a file -  fixed the issue.