### PR TITLE
Removed duplicate _LAST_COMMAND_INDICATOR_

### DIFF
--- a/themes/Custom.bgptemplate
+++ b/themes/Custom.bgptemplate
@@ -1,6 +1,6 @@
 # This is the custom theme template for gitprompt.sh
 
-# These are the defaults from the "Default" theme 
+# These are the defaults from the "Default" theme
 # You just need to override what you want to have changed
 override_git_prompt_colors() {
   GIT_PROMPT_THEME_NAME="Custom"
@@ -24,7 +24,7 @@ override_git_prompt_colors() {
   # GIT_PROMPT_STASHED="${BoldBlue}⚑ "    # the number of stashed files/dir
   # GIT_PROMPT_CLEAN="${BoldGreen}✔"      # a colored flag indicating a "clean" repo
 
-  ## For the command indicator, the placeholder _LAST_COMMAND_STATE_ 
+  ## For the command indicator, the placeholder _LAST_COMMAND_STATE_
   ## will be replaced with the exit code of the last command
   ## e.g.
   ## GIT_PROMPT_COMMAND_OK="${Green}✔-_LAST_COMMAND_STATE_ "    # indicator if the last command returned with an exit code of 0
@@ -34,7 +34,7 @@ override_git_prompt_colors() {
   # GIT_PROMPT_COMMAND_FAIL="${Red}✘-_LAST_COMMAND_STATE_"    # indicator if the last command returned with an exit code of other than 0
 
   ## template for displaying the current virtual environment
-  ## use the placeholder _VIRTUALENV_ will be replaced with 
+  ## use the placeholder _VIRTUALENV_ will be replaced with
   ## the name of the current virtual environment (currently CONDA and VIRTUAL_ENV)
   # GIT_PROMPT_VIRTUALENV="(${Blue}_VIRTUALENV_${ResetColor}) "
 
@@ -45,7 +45,7 @@ override_git_prompt_colors() {
 
   ## _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
   # GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"
-  # GIT_PROMPT_START_ROOT="_LAST_COMMAND_INDICATOR_ ${GIT_PROMPT_START_USER}"
+  # GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
   # GIT_PROMPT_END_USER=" \n${White}${Time12a}${ResetColor} $ "
   # GIT_PROMPT_END_ROOT=" \n${White}${Time12a}${ResetColor} # "
 
@@ -53,7 +53,7 @@ override_git_prompt_colors() {
   # GIT_PROMPT_SYMBOLS_AHEAD="↑·"             # The symbol for "n versions ahead of origin"
   # GIT_PROMPT_SYMBOLS_BEHIND="↓·"            # The symbol for "n versions behind of origin"
   # GIT_PROMPT_SYMBOLS_PREHASH=":"            # Written before hash of commit, if no name could be found
-  # GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L" # This symbol is written after the branch, if the branch is not tracked 
+  # GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING="L" # This symbol is written after the branch, if the branch is not tracked
 
   # branch name(s) that will use $GIT_PROMPT_MASTER_BRANCH color
   # To specify multiple branches, use


### PR DESCRIPTION
Removed a duplicate `_LAST_COMMAND_INDICATOR_` in the `GIT_PROMPT_START_ROOT` line of `Custom.bgptemplate`.