### PR TITLE
Fix incompatibility with an exported $CDPATH, fixes #501

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -10,6 +10,7 @@ function git_prompt_dir() {
   # assume the gitstatus.sh is in the same directory as this script
   # code thanks to http://stackoverflow.com/questions/59895
   if [[ -z "${__GIT_PROMPT_DIR:+x}" ]]; then
+    unset CDPATH
     local SOURCE="${BASH_SOURCE[0]}"
     while [[ -h "${SOURCE}" ]]; do
       local DIR="$( command cd -P "$( dirname "${SOURCE}" )" && pwd )"


### PR DESCRIPTION
Because `gitprompt.sh` uses `command cd` to find `__GIT_PROMPT_DIR` it
breaks if `$CDPATH` is used and exported.

* Add unset CDPATH

Interestingly this problem was actually discussed in the stack exchange page referenced in the source: https://bosker.wordpress.com/2012/02/12/bash-scripters-beware-of-the-cdpath/

FYI you do not need to `export CDPATH=...` for it to work as `cd` is a builtin, but some people do it anyway.