### PR TITLE
add GIT_PROMPT_START_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ GIT_PROMPT_ONLY_IN_REPO=1
 # GIT_PROMPT_START=...    # uncomment for custom prompt start sequence
 # GIT_PROMPT_END=...      # uncomment for custom prompt end sequence
 
+# GIT_PROMPT_START_PREFIX=... # uncomment for custom prefix for the prompt start sequence
+
 # as last entry source the gitprompt script
 # GIT_PROMPT_THEME=Custom # use custom theme specified in file GIT_PROMPT_THEME_FILE (default ~/.git-prompt-colors.sh)
 # GIT_PROMPT_THEME_FILE=~/.git-prompt-colors.sh
@@ -201,6 +203,11 @@ If you use a custom theme in `.git-prompt-colors.sh`, please set `GIT_PROMPT_THE
 #### Further customizations
 
 - You can define `GIT_PROMPT_START` and `GIT_PROMPT_END` to tweak your prompt.
+
+- You can define `GIT_PROMPT_START_PREFIX` to add something to the first line, like, a hostname
+  ```
+  GIT_PROMPT_START_PREFIX="\H"
+  ```
 
 - The default colors are defined within `prompt-colors.sh`, which is sourced by
   `gitprompt.sh`.  The colors used for various git status are defined in

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -240,12 +240,12 @@ function git_prompt_config() {
 
     if [[ -z "${GIT_PROMPT_START:+x}" ]] ; then
       if ${_isroot}; then
-        PROMPT_START="${GIT_PROMPT_START_ROOT-}"
+        PROMPT_START="${GIT_PROMPT_START_PREFIX:-}${GIT_PROMPT_START_ROOT-}"
       else
-        PROMPT_START="${GIT_PROMPT_START_USER-}"
+        PROMPT_START="${GIT_PROMPT_START_PREFIX:-}${GIT_PROMPT_START_USER-}"
       fi
     else
-      PROMPT_START="${GIT_PROMPT_START-}"
+      PROMPT_START="${GIT_PROMPT_START_PREFIX:-}${GIT_PROMPT_START-}"
     fi
 
     if [[ -z "${GIT_PROMPT_END:+x}" ]] ; then


### PR DESCRIPTION
This change is small and adds a prefix to the 1st line of the git prompt.
This adresses a need to add something in front of the line instead of trying to replace it completely with GIT_PROMPT_START