### PR TITLE
Do not modify the first subscript of array PROMPT_COMMAND

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -734,9 +734,25 @@ function add_to_end_of_prompt_command() {
 }
 
 function gp_install_prompt {
-  make_prompt_command_clean
-  add_to_end_of_prompt_command "setGitPrompt"
-  add_to_beginning_of_prompt_command "setLastCommandState"
+  # 5.1 supports PROMPT_COMMAND as an array
+  if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)); then
+    if [[ $(declare -p PROMPT_COMMAND 2>/dev/null) == "declare --"* ]]; then
+      make_prompt_command_clean
+      add_to_end_of_prompt_command "setGitPrompt"
+      add_to_beginning_of_prompt_command "setLastCommandState"
+    else
+      if [[ "${PROMPT_COMMAND[*]}" != *setGitPrompt* ]]; then
+        PROMPT_COMMAND+=(setGitPrompt)
+      fi
+      if [[ "${PROMPT_COMMAND[*]}" != *setLastCommandState* ]]; then
+        PROMPT_COMMAND=(setLastCommandState "${PROMPT_COMMAND[@]}")
+      fi
+    fi
+  else
+    make_prompt_command_clean
+    add_to_end_of_prompt_command "setGitPrompt"
+    add_to_beginning_of_prompt_command "setLastCommandState"
+  fi
 
   set_git_prompt_dir
   source "${__GIT_PROMPT_DIR}/git-prompt-help.sh"


### PR DESCRIPTION
In Bash 5.1 PROMPT_COMMAND can be either a semi-colon separated string or an array.

with this patch;

```sh
@falschgeld| ~ $ unset PROMPT_COMMAND; PROMPT_COMMAND=true ; source .bashrc ; declare -p PROMPT_COMMAND
declare -- PROMPT_COMMAND="setLastCommandState;_venv_enter;true;setGitPrompt"
@falschgeld| ~ $ unset PROMPT_COMMAND; PROMPT_COMMAND=(true) ; source .bashrc ; declare -p PROMPT_COMMAND
declare -a PROMPT_COMMAND=([0]="setLastCommandState" [1]="true" [2]="_venv_enter" [3]="setGitPrompt")
@falschgeld| ~ $ unset PROMPT_COMMAND[1]; source .bashrc ; declare -p PROMPT_COMMAND
declare -a PROMPT_COMMAND=([0]="setLastCommandState" [2]="_venv_enter" [3]="setGitPrompt")
@falschgeld| ~ $ unset PROMPT_COMMAND[2]; source .bashrc ; declare -p PROMPT_COMMAND
declare -a PROMPT_COMMAND=([0]="setLastCommandState" [3]="setGitPrompt" [4]="_venv_enter")
```

without

```sh
@falschgeld| ~ $ unset PROMPT_COMMAND; PROMPT_COMMAND=true ; source .bashrc ; declare -p PROMPT_COMMAND
declare -- PROMPT_COMMAND="setLastCommandState;_venv_enter;true;setGitPrompt"
@falschgeld| ~ $ unset PROMPT_COMMAND; PROMPT_COMMAND=(true) ; source .bashrc ; declare -p PROMPT_COMMAND
declare -a PROMPT_COMMAND=([0]="setLastCommandState;true;setGitPrompt" [1]="_venv_enter")
```

in my setup the old behavior isn't a problem, just a little bit awkward that it messes with the first subscript of the array.