### PR TITLE
fix bashrc path with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add to the `~/.bashrc`:
 ```
 if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
     GIT_PROMPT_ONLY_IN_REPO=1
-    source $HOME/.bash-git-prompt/gitprompt.sh
+    source "$HOME/.bash-git-prompt/gitprompt.sh"
 fi
 ```
 


### PR DESCRIPTION
If there are spaces in the user path (on windows having a username with spaces) the script doesnt load.