### PR TITLE
Fix minor ShellCheck violations

### DIFF
--- a/git-prompt-help.sh
+++ b/git-prompt-help.sh
@@ -52,18 +52,18 @@ git_prompt_examples() {
   cat <<EOF | sed 's/\\\[\\033//g' | sed 's/\\\]//g'
 These are examples of the git prompt:
 
-  ${p}`format_branch master`${GIT_PROMPT_REMOTE}${GIT_PROMPT_SYMBOLS_AHEAD}3${ResetColor}|${GIT_PROMPT_CHANGED}1${ResetColor}${s}  - on branch "master", ahead of remote by 3 commits, 1
+  ${p}$(format_branch master)${GIT_PROMPT_REMOTE}${GIT_PROMPT_SYMBOLS_AHEAD}3${ResetColor}|${GIT_PROMPT_CHANGED}1${ResetColor}${s}  - on branch "master", ahead of remote by 3 commits, 1
                      file changed but not staged
 
-  ${p}`format_branch status`${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_STAGED}2${ResetColor}${s}     - on branch "status", 2 files staged
+  ${p}$(format_branch status)${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_STAGED}2${ResetColor}${s}     - on branch "status", 2 files staged
 
-  ${p}`format_branch master`${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CHANGED}7${GIT_PROMPT_UNTRACKED}${ResetColor}${s}   - on branch "master", 7 files changed, some files untracked
+  ${p}$(format_branch master)${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CHANGED}7${GIT_PROMPT_UNTRACKED}${ResetColor}${s}   - on branch "master", 7 files changed, some files untracked
 
-  ${p}`format_branch master`${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CONFLICTS}2${GIT_PROMPT_CHANGED}3${ResetColor}${s}  - on branch "master", 2 conflicts, 3 files changed
+  ${p}$(format_branch master)${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CONFLICTS}2${GIT_PROMPT_CHANGED}3${ResetColor}${s}  - on branch "master", 2 conflicts, 3 files changed
 
-  ${p}`format_branch master`${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_STASHED}2${ResetColor}${s}     - on branch "master", 2 stash entries
+  ${p}$(format_branch master)${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_STASHED}2${ResetColor}${s}     - on branch "master", 2 stash entries
 
-  ${p}`format_branch experimental`${GIT_PROMPT_REMOTE}${GIT_PROMPT_SYMBOLS_BEHIND}2${GIT_PROMPT_SYMBOLS_AHEAD}3${ResetColor}${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CLEAN}${ResetColor}${s}
+  ${p}$(format_branch experimental)${GIT_PROMPT_REMOTE}${GIT_PROMPT_SYMBOLS_BEHIND}2${GIT_PROMPT_SYMBOLS_AHEAD}3${ResetColor}${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CLEAN}${ResetColor}${s}
                    - on branch "experimental"; your branch has diverged
                      by 3 commits, remote by 2 commits; the repository is
                      otherwise clean
@@ -71,7 +71,7 @@ These are examples of the git prompt:
   ${p}${GIT_PROMPT_BRANCH}${GIT_PROMPT_SYMBOLS_PREHASH}70c2952${ResetColor}${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CLEAN}${ResetColor}${s}    - not on any branch; parent commit has hash "70c2952"; the
                      repository is otherwise clean
 
-  ${p}`format_branch extra-features`${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING}${ResetColor}${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CHANGED}2${GIT_PROMPT_UNTRACKED}4${ResetColor}${s}
+  ${p}$(format_branch extra-features)${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING}${ResetColor}${GIT_PROMPT_SEPARATOR}${GIT_PROMPT_CHANGED}2${GIT_PROMPT_UNTRACKED}4${ResetColor}${s}
                    - on branch "extra-features"; no remote set (signalled by '${GIT_PROMPT_SYMBOLS_NO_REMOTE_TRACKING}${ResetColor}'),
                      2 files changed and 4 untracked files exist
 EOF

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -681,7 +681,7 @@ function gp_truncate_pwd {
 
 # Sets the window title to the given argument string
 function gp_set_window_title {
-  echo -ne "\[\033]0;"${@}"\007\]"
+  echo -ne "\[\033]0;$1\007\]"
 }
 
 function prompt_callback_default {

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -36,6 +36,7 @@ else
   remote_url='.'
 fi
 
+# shellcheck disable=SC2086
 gitstatus=$( LC_ALL=C git --no-optional-locks status ${_ignore_submodules} --untracked-files="${__GIT_PROMPT_SHOW_UNTRACKED_FILES:-normal}" --porcelain --branch )
 
 # if the status is fatal, exit now
@@ -185,7 +186,7 @@ if [[ -z "${upstream:+x}" ]] ; then
   upstream='^'
 fi
 
-UPSTREAM_TRIMMED=`echo $upstream |xargs`
+UPSTREAM_TRIMMED=$(echo $upstream | xargs)
 
 printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
   "${branch}${state}" \

--- a/gitstatus_pre-1.7.10.sh
+++ b/gitstatus_pre-1.7.10.sh
@@ -6,7 +6,7 @@
 # Alan K. Stebbens <aks@stebbens.org> [http://github.com/aks]
 
 # helper functions
-count_lines() { echo "${1}" | egrep -c "^${2}" ; }
+count_lines() { echo "${1}" | grep -Ec "^${2}" ; }
 all_lines() { echo "${1}" | grep -v "^$" | wc -l ; }
 
 if [[ -z "${__GIT_PROMPT_DIR-}" ]]; then
@@ -95,7 +95,6 @@ else
 
   # detect if the local branch have a remote tracking branch
   upstream=$( git rev-parse --abbrev-ref "${branch}"@{upstream} 2>&1 )
-
   if [[ "${?}" == 0 ]]; then
      # get the revision list, and count the leading "<" and ">"
     revgit=$( git rev-list --left-right "${remote_ref}...HEAD" 2>/dev/null )


### PR DESCRIPTION
- Replace deprecated backticks with $()
- Replace use of deprecated `egrep` with `grep -E`
- Disable ShellCheck false positive
- Every single use of `gp_set_window_title` has 1 positional parameter, so only interpolate `$1`

This is a good project, and I noticed that there were several issues that have already been fixed, or are old enough that they are not relevant (uses an EOL Linux Distribution). I have marked the following as to close. There are more, but I think this is a good start. Closing these old issues makes the repository seem more maintained, and it's easier to triage and look for existing issues when they are closed.

Closes #420 (stale, not enough information)
Closes #327 (stale, fixed on later Debian version)
Closes #225 (stale, fixed on later Ubuntu version)
Closes #347 (stale, fixed in later `bash-git-prompt` version)
Closes #440 (stale, could not reproduce, / fixed in later `bash-git-prompt` version)
Closes #494 (stale, not relevant)
Closes #291 (stale)
Closes #531 (duplicate of #466)
Closes #533 (stale / spam / bot)