### PR TITLE
readme: Cleanup inconsistent spacing and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This prompt is a port of the "Informative git prompt for zsh" which you can
 find [here](https://github.com/olivierverdier/zsh-git-prompt)
 
-A ``bash`` prompt that displays information about the current git repository.
+A `bash``prompt that displays information about the current git repository.
 In particular the branch name, difference with remote branch, number of files
 staged, changed, etc.
 
@@ -25,11 +25,13 @@ The prompt may look like the following:
 * ``(experimental↓2↑3|✔)``: on branch ``experimental``; your branch has diverged by 3 commits, remote by 2 commits; the repository is otherwise clean
 * ``(:70c2952|✔)``: not on any branch; parent commit has hash ``70c2952``; the repository is otherwise clean
 
-##  Prompt Structure
+## Prompt Structure
 
 By default, the general appearance of the prompt is::
 
-    (<branch> <upstream branch> <branch tracking>|<local status>)
+```plaintext
+(<branch> <upstream branch> <branch tracking>|<local status>)
+```
 
 The symbols are as follows:
 
@@ -51,7 +53,7 @@ The symbols are as follows:
   - ``↓m↑n``: branches diverged, other by ``m`` commits, yours by ``n`` commits
   - ``L``: local branch, not remotely tracked
 - Branch Symbol:<br />
-  	When the branch name starts with a colon ``:``, it means it's actually a hash, not a branch (although it should be pretty clear, unless you name your branches like hashes :-)
+  - When the branch name starts with a colon ``:``, it means it's actually a hash, not a branch (although it should be pretty clear, unless you name your branches like hashes :-)
 
 ## Installation
 
@@ -81,7 +83,8 @@ git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt -
 ```
 
 Add to the `~/.bashrc`:
-```
+
+```bash
 if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
     GIT_PROMPT_ONLY_IN_REPO=1
     source "$HOME/.bash-git-prompt/gitprompt.sh"
@@ -99,8 +102,9 @@ fi
 sudo install -m 666 gitprompt.fish /usr/share/fish/tools/web_config/sample_prompts/
 fish_config
 ```
-   to install the bash-git-prompt as a choice under the prompt tab of the web config. Selecting this will copy it to
-   ~/.config/fish/functions/fish_prompt.fish
+
+&nbsp;to install the bash-git-prompt as a choice under the prompt tab of the web config. Selecting this will copy it to
+`~/.config/fish/functions/fish_prompt.fish`
 
 - You can also do
 
@@ -108,13 +112,12 @@ fish_config
 mkdir -p ~/.config/fish/functions/
 cp gitprompt.fish ~/.config/fish/functions/fish_prompt.fish
 ```
-   to overwrite the current prompt with the bash-git-prompt directly
 
+&nbsp;to overwrite the current prompt with the bash-git-prompt directly
 
 ### All configs for .bashrc
 
 ```sh
-
 # Set config variables first
 GIT_PROMPT_ONLY_IN_REPO=1
 
@@ -171,6 +174,7 @@ in your home directory, then the Custom theme is used.**
 Ubuntu requires a bit more spacing for some characters so it has its own themes.
 
 These can be listed with `git_prompt_list_themes`:
+
 ```sh
 git_prompt_list_themes | grep Ubuntu
 ```
@@ -219,8 +223,8 @@ If you use a custom theme in `.git-prompt-colors.sh`, please set `GIT_PROMPT_THE
 - You can define `prompt_callback` function to tweak your prompt dynamically.
 
 ```sh
-function prompt_callback {
-    if [ `jobs | wc -l` -ne 0 ]; then
+prompt_callback() {
+    if [ $(jobs | wc -l) -ne 0 ]; then
         echo -n " jobs:\j"
     fi
 }
@@ -234,7 +238,6 @@ function prompt_callback {
   can set `GIT_PROMPT_ONLY_IN_REPO=1` before sourcing the gitprompt script
 
 - You can show an abbreviated `username/repo` in the prompt by setting `GIT_PROMPT_WITH_USERNAME_AND_REPO=1` and setting the placeholder `_USERNAME_REPO_` in your `GIT_PROMPT_PREFIX`. You can also add a `GIT_PROMPT_USERNAME_REPO_SEPARATOR=" | "` so the `username/repo` is nicely separated if there is a remote and if there is no remote, neither the username/repo part nor the separator will be shown. See the theme `Single_line_username_repo.bgptheme` for an example.
-
 
 - There is an indicator at the start of the prompt, which shows
   the result of the last executed command by if you put the placeholder
@@ -290,7 +293,6 @@ git_prompt_reset
 git_prompt_toggle
 ```
 
-
 **Enjoy!**
 
 ## Alternative RPM Install
@@ -298,39 +300,40 @@ git_prompt_toggle
 This project ships an RPM spec to simplify installation on RHEL and
 clones. If you wish to install from RPM, you may first build the RPM
 from scratch by following this procedure:
+
 * Clone this repository and tag the release with a version number
 
 ````sh
-    git tag -a -m "Tag release 1.1" 1.1
+git tag -a -m "Tag release 1.1" 1.1
 ````
 
 * Run the following command to create a tarball:
 
 ````sh
-    VER=$(git describe)
-    # replace dash with underscore to work around
-    # rpmbuild does not allow dash in version string
-    VER=${VER//\-/_}
-    git archive                                \
-        --format tar                           \
-        --prefix=bash-git-prompt-${VER}/       \
-        HEAD                                   \
-        --  *.sh                               \
-            *.fish                             \
-            README.md                          \
-            themes                             \
-      > bash-git-prompt-${VER}.tar
-    mkdir -p /tmp/bash-git-prompt-${VER}
-    sed "s/Version:.*/Version:        ${VER}/"          \
-        bash-git-prompt.spec                            \
-      > /tmp/bash-git-prompt-${VER}/bash-git-prompt.spec
-    OLDDIR=$(pwd)
-    cd /tmp
-    tar -uf ${OLDDIR}/bash-git-prompt-${VER}.tar      \
-            bash-git-prompt-${VER}/bash-git-prompt.spec
-    cd ${OLDDIR}
-    gzip bash-git-prompt-${VER}.tar
-    mv bash-git-prompt-${VER}.tar.gz bash-git-prompt-${VER}.tgz
+VER=$(git describe)
+# replace dash with underscore to work around
+# rpmbuild does not allow dash in version string
+VER=${VER//\-/_}
+git archive                                \
+    --format tar                           \
+    --prefix=bash-git-prompt-${VER}/       \
+    HEAD                                   \
+    --  *.sh                               \
+        *.fish                             \
+        README.md                          \
+        themes                             \
+    > bash-git-prompt-${VER}.tar
+mkdir -p /tmp/bash-git-prompt-${VER}
+sed "s/Version:.*/Version:        ${VER}/"          \
+    bash-git-prompt.spec                            \
+    > /tmp/bash-git-prompt-${VER}/bash-git-prompt.spec
+OLDDIR=$(pwd)
+cd /tmp
+tar -uf ${OLDDIR}/bash-git-prompt-${VER}.tar      \
+        bash-git-prompt-${VER}/bash-git-prompt.spec
+cd ${OLDDIR}
+gzip bash-git-prompt-${VER}.tar
+mv bash-git-prompt-${VER}.tar.gz bash-git-prompt-${VER}.tgz
 ````
 
 * Log into an RHEL or clones host and run:
@@ -338,24 +341,30 @@ from scratch by following this procedure:
 ````sh
 rpmbuild -ta bash-git-prompt-xxx.tar.gz
 ````
+
 Then you may publish or install the rpm from "~/rpmbuild/RPMS/noarch".
 
 ## License
+
 This code is under the [BSD 2 Clause (NetBSD) license][license].
 
 ## Who Are You?
+
 The current maintainer of the original bash-git-prompt is [Martin Gondermann][magicmonty].
 
 ## Contributing
+
 If you want to contribute you can look for issues with the label [up-for-grabs][upforgrabs].
 Please leave a comment on the issue, that you want to fix it, so others know, the labels are "taken".
 
 Pull requests are welcome. I will check them and merge them, if I think they help the project.
 
 ## Similar projects
-https://github.com/ohmybash/oh-my-bash
+
+- [oh-my-bash](https://github.com/ohmybash/oh-my-bash]
 
 ## Donations
+
 I accept tips through [Flattr][flattr].
 
 [![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=magicmonty&url=https%3A%2F%2Fgithub.com%2Fmagicmonty%2Fbash-git-prompt)


### PR DESCRIPTION
There were inconsistencies that I have addresses in these improvements to the README.

This additionally closes (Closing these old issues makes the repository seem more maintained, and it's easier to triage and look for existing issues when they are closed.):

- Closes #212 (fixed by 5b7c0672702956f854d2909f521eee90e11f78d8)
- Closes #362 (fixed by 5b7c0672702956f854d2909f521eee90e11f78d8)
- Closes #256 (fixed by #254)
- Closes #358 (stale, question addressed)
- Closes #435 (stale, question addressed)