### PR TITLE
Fix for fedora 39 bash color promt

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -321,9 +321,15 @@ function we_are_on_repo() {
 function update_old_git_prompt() {
   if [[ "${GIT_PROMPT_OLD_DIR_WAS_GIT:-0}" = 0 ]]; then
     OLD_GITPROMPT="${PS1}"
+    OLD_PROMPT_START="${PROMPT_START}"
   fi
 
   GIT_PROMPT_OLD_DIR_WAS_GIT=$(we_are_on_repo)
+}
+
+function restore_prompt() {
+  PS1="${OLD_GITPROMPT}"
+  PROMPT_START="${OLD_PROMPT_START}"
 }
 
 function setGitPrompt() {
@@ -332,7 +338,7 @@ function setGitPrompt() {
   local repo=$(git rev-parse --show-toplevel 2> /dev/null)
   if [[ ! -e "${repo}" ]] && [[ "${GIT_PROMPT_ONLY_IN_REPO-}" = 1 ]]; then
     # we do not permit bash-git-prompt outside git repos, so nothing to do
-    PS1="${OLD_GITPROMPT}"
+    restore_prompt
     return
   fi
 


### PR DESCRIPTION
When using bash-git-promt in togeter with fedora 39 bash-color-prompt the restoring of the original promt does not work.

This fix is a minimal fix to get it working on my mashine.