### PR TITLE
Resetting PROMPT_START/PROMPT_END on exit

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -320,6 +320,8 @@ function we_are_on_repo() {
 
 function update_old_git_prompt() {
   if [[ "${GIT_PROMPT_OLD_DIR_WAS_GIT:-0}" = 0 ]]; then
+    OLD_PROMPT_START="${PROMPT_START}"
+    OLD_PROMPT_END="${PROMPT_END}"
     OLD_GITPROMPT="${PS1}"
   fi
 
@@ -332,6 +334,8 @@ function setGitPrompt() {
   local repo=$(git rev-parse --show-toplevel 2> /dev/null)
   if [[ ! -e "${repo}" ]] && [[ "${GIT_PROMPT_ONLY_IN_REPO-}" = 1 ]]; then
     # we do not permit bash-git-prompt outside git repos, so nothing to do
+    PROMPT_START=${OLD_PROMPT_START}
+    PROMPT_END=${OLD_PROMPT_END}
     PS1="${OLD_GITPROMPT}"
     return
   fi


### PR DESCRIPTION
/fixes #539 

The issue seems to be caused by the logic here:
https://github.com/magicmonty/bash-git-prompt/blob/51080c22b2cebb63111379f4eacd22cda199684b/gitprompt.sh#L249-L272

Basically, the values of both `PROMPT_START` and `PROMPT_END` are being set accordingly when entering a git repository, but never being reset to their original values upon exiting.  

This PR adds a couple lines to capture the original values of `PROMPT_START` and `PROMPT_END` on the way in and then resets the values accordingly on the way out.