### PR TITLE
Update BlackOrWhite.bgptheme

### DIFF
--- a/themes/BlackOrWhite.bgptheme
+++ b/themes/BlackOrWhite.bgptheme
@@ -453,8 +453,8 @@ override_git_prompt_colors() {
   GIT_PROMPT_UPSTREAM="${PS1Color} ${PS1ResetColor}{${PS1Color}_UPSTREAM_${PS1ResetColor}}"
 
   GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
-  GIT_PROMPT_END_USER="${ResetColor}${PS1SartEndColor}\n${PS1SartEndColor}${PromptEndUser}${ResetColor} "
-  GIT_PROMPT_END_ROOT="${ResetColor}${PS1SartEndColor}\n${PS1SartEndColor}${PromptEndRoot}${ResetColor} "
+  GIT_PROMPT_END_USER="${ResetColor}\n${PS1SartEndColor}${PromptEndUser}${ResetColor} "
+  GIT_PROMPT_END_ROOT="${ResetColor}\n${PS1SartEndColor}${PromptEndRoot}${ResetColor} "
 }
 
 reload_git_prompt_colors "BlackOrWhite"

--- a/themes/BlackOrWhite.bgptheme
+++ b/themes/BlackOrWhite.bgptheme
@@ -453,8 +453,8 @@ override_git_prompt_colors() {
   GIT_PROMPT_UPSTREAM="${PS1Color} ${PS1ResetColor}{${PS1Color}_UPSTREAM_${PS1ResetColor}}"
 
   GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"
-  GIT_PROMPT_END_USER="${ResetColor}${PS1SartEndColor}\n${PromptEndUser}${ResetColor} "
-  GIT_PROMPT_END_ROOT="${ResetColor}${PS1SartEndColor}\n${PromptEndRoot}${ResetColor} "
+  GIT_PROMPT_END_USER="${ResetColor}${PS1SartEndColor}\n${PS1SartEndColor}${PromptEndUser}${ResetColor} "
+  GIT_PROMPT_END_ROOT="${ResetColor}${PS1SartEndColor}\n${PS1SartEndColor}${PromptEndRoot}${ResetColor} "
 }
 
 reload_git_prompt_colors "BlackOrWhite"


### PR DESCRIPTION
Fix a bug where resizing the terminal window changes prompt color.
A picture of gnome terminal window (ubuntu 22.04) after resizing it:
![Screenshot from 2024-02-29 12-04-45](https://github.com/magicmonty/bash-git-prompt/assets/2247169/4a921452-49da-4c6f-b786-56ee5516e44e)
After applying this fix the color stays stable and isn't affected by resizing of window:
![Screenshot from 2024-02-29 12-07-44](https://github.com/magicmonty/bash-git-prompt/assets/2247169/169eb2bd-30f1-4107-9576-91648b6ea259)
