### PR TITLE
RPM build instructions: ensure LICENSE.txt included in tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ git archive                                \
     HEAD                                   \
     --  *.sh                               \
         *.fish                             \
+        LICENSE.txt                        \
         README.md                          \
         themes                             \
     > bash-git-prompt-${VER}.tar


### PR DESCRIPTION
As otherwise `rpmbuild` barfs (at least on Fedora 40)