### PR TITLE
Add end color to Single_line

### DIFF
--- a/themes/Single_line.bgptheme
+++ b/themes/Single_line.bgptheme
@@ -4,7 +4,7 @@ override_git_prompt_colors() {
 
   GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${White}${Time12a}${ResetColor} ${BoldYellow}${PathShort}${ResetColor}"
   GIT_PROMPT_END_USER="${ResetColor} $ "
-  GIT_PROMPT_END_ROOT="${BoldRed} # "
+  GIT_PROMPT_END_ROOT="${BoldRed} #${ResetColor} "
 }
 
 reload_git_prompt_colors "Single_line"


### PR DESCRIPTION
Using the Single_line theme, I was seeing that my text was always showing up as BoldRed. Not sure if that is the intent of this theme, but this adds a reset so the color returns to normal.