### PR TITLE
fix: prevent shell hang in git worktrees

### DIFF
--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -583,7 +583,7 @@ function updatePrompt() {
   export GIT_INDEX_FILE="${GIT_INDEX_PRIVATE}"
 
   local -a git_status_fields
-  while IFS=$'\n' read -r line; do git_status_fields+=("${line}"); done < <("${__GIT_STATUS_CMD}" 2>/dev/null)
+  while IFS=$'\n' read -r line; do git_status_fields+=("${line}"); done < <("${__GIT_STATUS_CMD}" 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- 2>/dev/null)
 
   export GIT_BRANCH
   GIT_BRANCH=$(replaceSymbols "${git_status_fields[0]}")

--- a/gitprompt.sh
+++ b/gitprompt.sh
@@ -6,7 +6,7 @@
 function async_run() {
   {
     eval "$*" &> /dev/null
-  }&
+  } 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
 }
 
 function async_run_zsh() {
@@ -14,7 +14,7 @@ function async_run_zsh() {
     eval "$*" &> /dev/null
 
   # `true` is used here to allow bash to parse the script, as the zsh `&!` syntax will otherwise stop parsing prior to any execution.
-  }&! true
+  } 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &! true
 }
 
 


### PR DESCRIPTION
Three places in `gitprompt.sh` spawn subprocesses without closing inherited shell file
  descriptors (fds 3–9). On systems running `git-fsmonitor` or slow credential helpers,
  those daemons inherit the open fds and are slow to exit, leaving the shell blocked
  indefinitely. The hang is most reliably reproduced inside a git worktree, where a second
  bug causes `checkUpstream` to trigger `git fetch` on every prompt.

  ## Bug 1: `async_run`/`async_run_zsh` inherit open file descriptors

  `git fetch` is backgrounded without closing inherited fds. Subprocesses like
  `git-remote-https` hold them open during network I/O, blocking any reader of those same
  pipe ends.

  Fix: add `3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-` before `&`.

  ## Bug 2: `checkUpstream` looks for `FETCH_HEAD` in the wrong place in worktrees

  In a git worktree, `.git` is a plain text file, not a directory.
  `${repo}/.git/FETCH_HEAD` can never exist, so the staleness check always fires —
  triggering `git fetch` on every prompt, which feeds back into bug 1.

  Fix: use `git rev-parse --git-common-dir` to find where `FETCH_HEAD` actually lives.

  ## Bug 3: `__GIT_STATUS_CMD` inherits open file descriptors

  `gitstatus.sh` is invoked inside a command/process substitution without closing the
  parent shell's internal fds. `git status` and its descendants (e.g. `git-fsmonitor`)
  inherit those fds and can hold them open indefinitely, blocking `updatePrompt`.

  Fix: add `3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-` to the `__GIT_STATUS_CMD` invocation.

## Bug 4: `gitstatus.sh` herestring deadlock on bash 5.3+

  Bash 5.3 introduced a regression where herestrings (`<<<`) of 512 bytes or more cause
  a deadlock at the `PIPE_BUF` boundary. The `while read ... done <<< "${gitstatus}"`
  loop in `gitstatus.sh` parses the output of `git status --porcelain`. In any repository
  with enough modified or untracked files to produce >= 512 bytes of status output, the
  shell hangs indefinitely.

  This affects macOS users with Homebrew bash 5.3.9 where `#!/usr/bin/env bash` resolves
  to the newer version; the system `/bin/bash` (3.2) is unaffected.

  Fix: replace `done <<< "${gitstatus}"` with `done < <(printf '%s\n' "${gitstatus}")`,
  using process substitution instead of a herestring.

  Ref: https://github.com/obra/superpowers/issues/571